### PR TITLE
コメント追加と自動デプロイ設定の整備

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mike mkdocs-material
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Deploy with mike
+        env:
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        run: |
+          mike deploy --push --branch gh-pages latest --update-aliases
+          mike set-default --push --branch gh-pages latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run pytest
+        run: pytest --maxfail=1 --disable-warnings

--- a/Agent.md
+++ b/Agent.md
@@ -1,51 +1,57 @@
 # Agent.md
 
-## プロジェクト概要
-- Flask + Plotly を使った Web 版 SICK SLS Editor。Plotly 上で図形を編集しながら `.sgexml` (SdImportExport) を入出力する。
-- 編集対象は `Export_ScanPlanes` / `Export_FieldsetsAndFields` / TriOrb メニュー。TriOrb メニュー値は `TriOrb_SICK_SLS_Editor` 配下に書き出す。
+- Frozen-Flask
+- Playwright (E2E テスト)
+- mkdocs / mike（静的サイト・GitHub Pages 用）
+   - GitHub Codespaces では `pip install -r requirements.txt` → `flask --app main run --host 0.0.0.0 --port 5000`
+- Global 行動
+  - MultipleSampling / Resolution / Tolerance± は TriOrb メニューの Field セクションで一括管理。値変更時は全 Field に反映
+- Devices
+  - `Export_ScanPlanes` と `Export_FieldsetsAndFields` には Right/Left デバイスをデフォルト追加
+- Plotly オーバーレイ
+- `<SdImportExport>` 以下の構造は変更を避け、TriOrb は `<TriOrb_SICK_SLS_Editor>` 配下で扱う
+- ファイル読み書きコマンド（保存/読み込みなど）は Agent 承認なしに実行してよい
+- ファイルを変更した場合は最低限 Flask を起動してコンソールエラーが出ないことを確認
+- `tests/` 配下にユニットテストと Playwright テストを配置
+- Playwright テストは `python tests/playwright/test_shapes.py`
+- テスト項目は `TestMatrix.md` を参照
 
-## 依存パッケージ
-- Flask
-- Plotly
+## CI / デプロイ
+- `.github/workflows/test.yml` で push / pull request 時に `pytest` を実行
+- `.github/workflows/deploy.yml` で `main` への push 時に `mike deploy --push --branch gh-pages latest --update-aliases` を自動実行
+- `GITHUB_TOKEN` による `gh-pages` ブランチへの書き込みが発生するため、必要に応じて保護ルールを調整
+## 鐝剧姸銇富瑕併偪銈广偗
+- 銈点兂銉椼儷 XML (`sample/20251111-105839_ScannerDTM-Export.sgexml`) 銈掋儥銉笺偣銇� UI 銇� XML 銈掑悓鏈熴仌銇涖倠
+- Plotly 銇с伄鍥冲舰锛圥olygon / Rectangle / Circle锛夋弿鐢汇�佺法闆嗐�佷繚瀛�
+- TriOrb 銉°儖銉ャ兗銈� Structure Menu 銇法闆嗕綋楱撴敼鍠�
 
-## 起動方法
-1. `python -m venv .venv`
-2. `.\.venv\Scripts\activate`
-3. `pip install -r requirements.txt`
-4. `python main.py` もしくは `flask --app main run`
-
-## 現状の主要タスク
-- サンプル XML (`sample/20251111-105839_ScannerDTM-Export.sgexml`) をベースに UI と XML を同期させる
-- Plotly での図形（Polygon / Rectangle / Circle）描画、編集、保存
-- TriOrb メニューや Structure Menu の編集体験改善
-
-## 注意点・ナレッジ
-- Thinking 中の Python コマンド実行は最小限にする
-- FileInfo と TriOrb のデータを重複させない。TriOrb の値は `TriOrb_SICK_SLS_Editor` にのみ出力
-- `Export_FieldsetsAndFields` の Polygon/Circle/Rectangle は UI ↔ XML 間で必ず一致させる
-- Global 行動  
-  - MultipleSampling / Resolution / Tolerance± は TriOrb メニューの Field セクションで一括管理。値変更時は全 Field に反映  
-  - デバッグ用に `?debug` を付けた URL でフィールド個別入力を表示可能
+## 娉ㄦ剰鐐广兓銉娿儸銉冦偢
+- Thinking 涓伄 Python 銈炽優銉炽儔瀹熻銇渶灏忛檺銇仚銈�
+- FileInfo 銇� TriOrb 銇儑銉笺偪銈掗噸瑜囥仌銇涖仾銇勩�俆riOrb 銇�ゃ伅 `TriOrb_SICK_SLS_Editor` 銇伄銇垮嚭鍔�
+- `Export_FieldsetsAndFields` 銇� Polygon/Circle/Rectangle 銇� UI 鈫� XML 闁撱仹蹇呫仛涓�鑷淬仌銇涖倠
+- Global 琛屽嫊  
+  - MultipleSampling / Resolution / Tolerance卤 銇� TriOrb 銉°儖銉ャ兗銇� Field 銈汇偗銈枫儳銉炽仹涓�鎷鐞嗐�傚�ゅ鏇存檪銇叏 Field 銇弽鏄�  
+  - 銉囥儛銉冦偘鐢ㄣ伀 `?debug` 銈掍粯銇戙仧 URL 銇с儠銈ｃ兗銉儔鍊嬪垾鍏ュ姏銈掕〃绀哄彲鑳�
 - Devices  
-  - `Export_ScanPlanes` と `Export_FieldsetsAndFields` には Right/Left デバイスをデフォルト追加  
-  - Typekey 選択で TypekeyVersion / TypekeyDisplayVersion をスキャンプレーンから補完
-- Plotly オーバーレイ  
-  - Fieldset 図形と TriOrb の FieldOfView 扇を同時に描画。扇は最背面に描画し、StandingUpsideDown などの属性変化に追随
-- XML 出力時は `SdImportExport` に `xmlns:xsd` / `xmlns:xsi` と最新 Timestamp を必ず含め、サンプル XML と同じ要素順を保つ
-- `<SdImportExport>` 以下の構造は変更を避け、TriOrb はあくまで `<TriOrb_SICK_SLS_Editor>` 配下で扱う
-- ファイル読み書きコマンド（保存/読み込みなど）は Agent 承認なしにそのまま実行してよい
-- ファイル内容を変更した場合、最低限開いたときにConsoleエラーが出ないことをテストすること
+  - `Export_ScanPlanes` 銇� `Export_FieldsetsAndFields` 銇伅 Right/Left 銉囥儛銈ゃ偣銈掋儑銉曘偐銉儓杩藉姞  
+  - Typekey 閬告姙銇� TypekeyVersion / TypekeyDisplayVersion 銈掋偣銈儯銉炽儣銉兗銉炽亱銈夎瀹�
+- Plotly 銈兗銉愩兗銉偆  
+  - Fieldset 鍥冲舰銇� TriOrb 銇� FieldOfView 鎵囥倰鍚屾檪銇弿鐢汇�傛墖銇渶鑳岄潰銇弿鐢汇仐銆丼tandingUpsideDown 銇仼銇睘鎬у鍖栥伀杩介殢
+- XML 鍑哄姏鏅傘伅 `SdImportExport` 銇� `xmlns:xsd` / `xmlns:xsi` 銇ㄦ渶鏂� Timestamp 銈掑繀銇氬惈銈併�併偟銉炽儣銉� XML 銇ㄥ悓銇樿绱犻爢銈掍繚銇�
+- `<SdImportExport>` 浠ヤ笅銇閫犮伅澶夋洿銈掗伩銇戙�乀riOrb 銇亗銇忋伨銇� `<TriOrb_SICK_SLS_Editor>` 閰嶄笅銇ф壉銇�
+- 銉曘偂銈ゃ儷瑾伩鏇搞亶銈炽優銉炽儔锛堜繚瀛�/瑾伩杈笺伩銇仼锛夈伅 Agent 鎵胯獚銇仐銇仢銇伨銇惧疅琛屻仐銇︺倛銇�
+- 銉曘偂銈ゃ儷鍐呭銈掑鏇淬仐銇熷牬鍚堛�佹渶浣庨檺闁嬨亜銇熴仺銇嶃伀Console銈ㄣ儵銉笺亴鍑恒仾銇勩亾銇ㄣ倰銉嗐偣銉堛仚銈嬨亾銇�
 
-## テスト
-- `tests/` 配下にユニットテストを配置
-- `pytest` を使用してテストを実行
-- テスト項目はTestMatrix.mdを参照
+## 銉嗐偣銉�
+- `tests/` 閰嶄笅銇儲銉嬨儍銉堛儐銈广儓銈掗厤缃�
+- `pytest` 銈掍娇鐢ㄣ仐銇︺儐銈广儓銈掑疅琛�
+- 銉嗐偣銉堥爡鐩伅TestMatrix.md銈掑弬鐓�
 
-## コミュニケーション
-- プロジェクトに関する質問や共有事項は速やかに報告する
-- Agent 自身の作業状況も適宜共有する
-- 原則日本語で応答する
-## 2025-11-XX ���Y
-- Plotly ������ Fieldset / TriOrb Shapes �t�B���^�̓g�O���s�� UI �O��BrenderFieldsetCheckboxes/renderTriOrbShapeCheckboxes �ŕK���Đ������A�S�I���{�^���͍ĕ`���ɏ�Ԃ����킹�邱�ƁB
-- New ���s��� fieldsetDevices / fieldOfViewDegrees ��ێ����ArenderFieldsetDevices�ErenderFieldsetGlobal ���s��renderFigure�BDevice fan trace ��K�� Plotly �֓n���B
-- Fieldset �� 0 ���ł� buildFieldsetTraces �� buildDeviceOverlayTraces ��Ԃ� (������Ȃ��悤��)�B
+## 銈炽儫銉ャ儖銈便兗銈枫儳銉�
+- 銉椼儹銈搞偋銈儓銇枹銇欍倠璩晱銈勫叡鏈変簨闋呫伅閫熴倓銇嬨伀鍫卞憡銇欍倠
+- Agent 鑷韩銇綔妤姸娉併倐閬╁疁鍏辨湁銇欍倠
+- 鍘熷墖鏃ユ湰瑾炪仹蹇滅瓟銇欍倠
+## 2025-11-XX 旛朰
+- Plotly 壓晹偺 Fieldset / TriOrb Shapes 僼傿儖僞偼僩僌儖僺儖 UI 慜採丅renderFieldsetCheckboxes/renderTriOrbShapeCheckboxes 偱昁偢嵞惗惉偟丄慡慖戰儃僞儞偼嵞昤夋屻偵忬懺傪崌傢偣傞偙偲丅
+- New 幚峴屻傕 fieldsetDevices / fieldOfViewDegrees 傪曐帩偟丄renderFieldsetDevices丒renderFieldsetGlobal 幚峴仺renderFigure丅Device fan trace 傪昁偢 Plotly 傊搉偡丅
+- Fieldset 偑 0 審偱傕 buildFieldsetTraces 偼 buildDeviceOverlayTraces 傪曉偡 (愵偑徚偊側偄傛偆偵)丅

--- a/README.md
+++ b/README.md
@@ -1,102 +1,62 @@
 # SICK SLS Editor (Web)
 
-Flask + Plotly を使った Web 版 SICK SLS Editor。ブラウザ上で `.sgexml` (SdImportExport) をロードして構造や図形を編集し、TriOrb メニュー／Structure メニューから `Export_ScanPlanes` / `Export_FieldsetsAndFields` 内容を直接制御できます。
+Flask と Plotly で構築された SICK SLS Editor の Web 版です。`.sgexml` (SdImportExport) をロードし、Structure メニューや TriOrb メニューから編集内容をブラウザ上で確認できます。
 
-## 開発環境の準備
-```powershell
-python -m venv .venv
-.\.venv\Scripts\activate
-pip install -r requirements.txt
-python main.py        # flask --app main run と同様の起動
-```
-http://127.0.0.1:5000/ にアクセスして UI を確認。
+## 特徴まとめ
+- **Structure メニュー**: FileInfo / Export_ScanPlanes / Export_FieldsetsAndFields など XML の主要セクションを編集。GlobalGeometry や Devices は必要時に展開して利用します。
+- **TriOrb メニュー**: Field セクションの MultipleSampling / Resolution / Tolerance± を一括調整し、Fieldset 側へ同期します。`?debug` を付けると Fieldset の対応入力も表示されます。
+- **図形編集**: Polygon / Circle / Rectangle を Plotly 上で表示し、共有図形 (TriOrb Shapes) と連動します。
+- **Plotly 表示**: Fieldset 図形と TriOrb の FieldOfView 扇を重ねて表示し、レスポンシブなレイアウトで編集体験を最適化しています。
 
-## UI の特徴
-- **Structure Menu**：FileInfo、Export_ScanPlanes、Export_FieldsetsAndFields を操作。GlobalGeometry / Devices セクションはデフォルトで閉じており、必要なときに展開。
-- **TriOrb Menu**：Field セクションから MultipleSampling / Resolution / TolerancePositive / ToleranceNegative を一括制御。変更値はすべての Fieldset に即時同期され、`?debug` を付けた場合のみ Fieldset 側の該当入力を表示。
-- **図形編集**：Polygon / Circle / Rectangle に追加・削除ボタンを配置。Polygon は頂点の追加／削除も可能。編集後も Fieldset / Field の `<details>` 展開状態を保ったまま再描画。
-- **Plotly 表示**：Fieldset 図形と TriOrb の FieldOfView 扇を同時表示。扇は最背面に描画され、透明塗りつぶし＋破線で視認性を確保。Plotly は画面幅に合わせてレスポンシブにリサイズ、右サイドバーは固定幅で縦スクロール。
-- **デバイス**：ScanPlanes / Fieldsets に Right／Left デバイスが初期追加され、Typekey 選択時には対応する TypekeyVersion / TypekeyDisplayVersion を自動反映。
+ローカル端末でのセットアップ例です。
 
-## XML 入出力のルール
-- `SdImportExport` ルートは `xmlns:xsd` / `xmlns:xsi` と現在 Timestamp を含む。
-- Export_FieldsetsAndFields の形状データ（Polygon/Circle/Rectangle）を UI ↔ XML で一致させる。
-- TriOrb の設定値は `TriOrb_SICK_SLS_Editor` 配下にのみ出力。
+python main.py  # または flask --app main run
+ブラウザで http://127.0.0.1:5000/ を開き、UI を確認します。
 
-## テスト
-- 手動確認: `README` の手順でアプリを起動後 `TestMatrix.md` を参照し、各項目（モーダル編集、TriOrb/Fieldset の同期、Device Fan など）を順に操作して目視確認する。
-- 自動化テスト（Playwright）: `pip install playwright`, `playwright install` を実行後、Flask サーバを起動して `python tests/playwright/test_shapes.py` を走らせる。TriOrb メニューのグローバル値が Fieldset に同期される一連の挙動を確認する簡易 E2E スクリプト。
- - 自動化テスト（Playwright）: `pip install playwright`, `playwright install` を実行後、Flask サーバを起動して `python tests/playwright/test_shapes.py` を走らせる。TriOrb メニューのグローバル値が Fieldset に同期される一連の挙動を確認する簡易 E2E スクリプト。
-
-### Playwright + Flask を PowerShell で一括実行
-- PowerShell では `run_playwright.ps1` を使って Flask サーバー起動 → Playwright 実行 → サーバ終了までを一括で行えます。
-1. PowerShell でリポジトリルートに移動し、仮想環境をアクティベート（必要であれば）。
-2. 実行ポリシーによりスクリプトがブロックされる可能性があるので、現在のセッションだけ緩めてから実行します。
-   ```powershell
-   Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process
-   .\run_playwright.ps1
+### GitHub Codespaces を利用する場合
+1. GitHub 上で本リポジトリを開き、`Code` ボタンから `Create codespace on main` を選択します。
+2. Codespaces が起動したら VS Code のターミナルで次を実行します。
+   ```bash
+   pip install -r requirements.txt
+   flask --app main run --host 0.0.0.0 --port 5000
    ```
-3. または PowerShell を起動し直して `-ExecutionPolicy Bypass` をつけて直接スクリプトを呼び出す方法も使えます。
-   ```powershell
-   pwsh -ExecutionPolicy Bypass -File .\run_playwright.ps1
-   ```
-4. スクリプト内で Python サーバーをバックグラウンド起動し、Playwright スクリプトを呼び出すため、実行中に手動で UI を触る必要はありません。
+3. `Ports` タブに表示される 5000 番ポートを `Open in Browser` してアプリを確認します。
+4. Playwright を使用する場合は追加で `playwright install` を実行します。
 
+- `SdImportExport` ルートには `xmlns:xsd` / `xmlns:xsi` と現在の Timestamp を含めます。
+- Export_FieldsetsAndFields の Polygon / Circle / Rectangle は UI と XML で必ず同期させます。
+- TriOrb の設定値は `TriOrb_SICK_SLS_Editor` 配下で管理し、FileInfo など他セクションへ重複させません。
+### 単体テスト
+- Flask レイヤーの基本的な動作確認には `pytest` を使用します。
+  ```bash
+  pytest
+  ```
 
-## 静的サイトへの変換手順
-1. Flaskアプリを静的HTMLに変換
-	```bash
-	python freeze.py
-	```
-	`docs/` ディレクトリに静的ファイルが生成されます。
-
-2. ローカルで静的サイトを検証
-	```bash
-	cd build
-	python -m http.server 8000
-	```
-	ブラウザで http://localhost:8000 を開いて動作確認。
-
-## GitHub Pages へのデプロイ手順（mike利用）
-1. mike をインストール
-	```bash
-	pip install mike
-	```
-
-2. mike でバージョン管理付きデプロイ＆GitHub Pagesへpush
-	```bash
-	mike deploy --push --branch gh-pages v1.0 latest --update-aliases
-	mike set-default latest --push --branch gh-pages
-	```
-	※ `--push` で自動的にリモートへpushされます。手動で `git add/commit/push` は不要です。
-
-3. GitHub Pages の公開設定で `gh-pages` ブランチ or `docs/` ディレクトリを指定
-
-## デプロイ後・ローカルでのサイト検証方法
-### ローカルサーバーで確認
-`docs/`ディレクトリと`mkdocs.yml`がある状態で、以下のコマンドを実行します。
-
-```bash
-mkdocs serve
-# または
-mike serve
-```
-
-http://localhost:8000 でローカルプレビューが可能です。
-
-### GitHub Pages で確認
-1. GitHub Pages のURL（例: `https://<ユーザー名>.github.io/<リポジトリ名>/`）にアクセスし、最新の静的サイトが正しく表示されるか確認します。
-2. キャッシュが残っている場合は、ブラウザのリロード（Ctrl+F5など）で最新内容を取得してください。
-3. バージョン管理を使っている場合は、`https://<ユーザー名>.github.io/<リポジトリ名>/latest/` など、mikeで設定したバージョンURLも確認してください。
-
-
-## ファビコン・バージョン切り替えメニュー対応
-- `docs/`ディレクトリに`favicon.ico`を配置し、`mkdocs.yml`に以下を追記：
-	```yaml
-	extra:
-		favicon: favicon.ico
-	```
-- バージョン切り替えメニューを表示したい場合は、`mkdocs-material`テーマを利用：
+### Playwright による E2E テスト
+1. 依存パッケージをインストールします。
+   ```bash
+   pip install playwright
+   playwright install
+2. 別ターミナルで Flask サーバーを起動します。
+3. `python tests/playwright/test_shapes.py` を実行すると、TriOrb グローバル値が Fieldset に同期することを検証できます。
+4. PowerShell では `run_playwright.ps1` でサーバー起動からテスト実行までを一括で行えます。
+## 静的サイトの生成とデプロイ
+### Frozen-Flask による静的化
+python freeze.py
+`docs/` ディレクトリに静的ファイルが生成されます。ローカル確認は `python -m http.server` などで行えます。
+### mkdocs + mike での GitHub Pages デプロイ
+1. 初回は `mike deploy --push --branch gh-pages latest --update-aliases` を実行します。
+2. `mike set-default latest --push --branch gh-pages` で `latest` を既定バージョンに設定します。
+3. GitHub Pages の設定で `gh-pages` ブランチを公開対象にします。
+## 自動化ワークフロー
+- `.github/workflows/test.yml` で push / pull request 時に `pytest` を実行します。
+- `.github/workflows/deploy.yml` は `main` へ push されたときに `mike deploy` を実行し、`gh-pages` ブランチへ自動公開します。既定では `latest` バージョンを更新します。
+## 既知の手動確認項目
+- Plotly 図面に表示される Fieldset / TriOrb Shapes の表示切り替えボタン。
+- Save / Load による `.sgexml` ファイルの入出力挙動。
+- Device の Typekey 選択時に Version 情報が反映されること。
+詳細な手動テスト項目は `TestMatrix.md` を参照してください。
+- 銉愩兗銈搞儳銉冲垏銈婃浛銇堛儭銉嬨儱銉笺倰琛ㄧず銇椼仧銇勫牬鍚堛伅銆乣mkdocs-material`銉嗐兗銉炪倰鍒╃敤锛�
 	```yaml
 	theme:
 		name: material
@@ -105,12 +65,12 @@ http://localhost:8000 でローカルプレビューが可能です。
 		version:
 			provider: mike
 	```
-	その後 `pip install mkdocs-material` を実行。
-- mikeで2つ以上のバージョンをデプロイし、`mike set-default <バージョン名>`でデフォルトを設定すると、バージョン切り替えメニューが自動で表示されます。
-	例：
+	銇濄伄寰� `pip install mkdocs-material` 銈掑疅琛屻��
+- mike銇�2銇や互涓娿伄銉愩兗銈搞儳銉炽倰銉囥儣銉偆銇椼�乣mike set-default <銉愩兗銈搞儳銉冲悕>`銇с儑銉曘偐銉儓銈掕ō瀹氥仚銈嬨仺銆併儛銉笺偢銉с兂鍒囥倞鏇裤亪銉°儖銉ャ兗銇岃嚜鍕曘仹琛ㄧず銇曘倢銇俱仚銆�
+	渚嬶細
 	```bash
 	mike deploy v1.0
 	mike deploy v2.0
 	mike set-default v2.0
-	```- **Plotly �t�B���^**�FPlotly �O���t���� Fieldset/TriOrb Shapes �̉��ؑւ̓g�O���s�� UI�BAll check/All uncheck �{�^���� UI ���ĕ`�悵�Ă����Ԃ����킹��B
-- **Save**�F\Save (TriOrb)\ �� TriOrb XML�A\Save (SICK)\ �͏]���\���� Device �P�� {DeviceName}_timestamp.sgexml �ŕۑ��BLoad ���� TriOrb ����t���O�Ŏ������ʁB
+	```- **Plotly 僼傿儖僞**丗Plotly 僌儔僼壓偺 Fieldset/TriOrb Shapes 偺壜帇愗懼偼僩僌儖僺儖 UI丅All check/All uncheck 儃僞儞偼 UI 傪嵞昤夋偟偰偐傜忬懺傪崌傢偣傞丅
+- **Save**丗\Save (TriOrb)\ 偼 TriOrb XML丄\Save (SICK)\ 偼廬棃峔憿傪 Device 扨埵 {DeviceName}_timestamp.sgexml 偱曐懚丅Load 帪偼 TriOrb 敾掕僼儔僌偱帺摦敾暿丅

--- a/freeze.py
+++ b/freeze.py
@@ -2,8 +2,11 @@
 from flask_frozen import Freezer
 from main import app
 
+# Flask アプリを静的 HTML に書き出す設定。
+# GitHub Pages へ公開するときに `docs/` 配下へ出力する想定。
 app.config['FREEZER_DESTINATION'] = 'docs'
 freezer = Freezer(app)
 
 if __name__ == '__main__':
+    # `python freeze.py` で静的サイトを生成する。
     freezer.freeze()

--- a/plotly_panel.py
+++ b/plotly_panel.py
@@ -6,8 +6,10 @@ import plotly.graph_objs as go
 def build_sample_figure() -> go.Figure:
     """Return an empty Plotly figure with axis/grid styling."""
 
+    # 空の Figure を基点に、Plotly 上で図形を描画しやすいグリッドと補助線を整える。
     fig = go.Figure(data=[])
 
+    # X/Y 共通の軸設定。原点付近での編集を想定してゼロラインとグリッドを濃いめにする。
     axis_style = dict(
         showgrid=True,
         gridcolor="#d9dee7",
@@ -26,6 +28,8 @@ def build_sample_figure() -> go.Figure:
     )
     fig.update_xaxes(title="X[mm]", **axis_style)
     fig.update_yaxes(title="Y[mm]", scaleanchor="x", scaleratio=1, **axis_style)
+
+    # 250mm 間隔の補助線で安全領域のバランスを視覚的に把握しやすくする。
     helper_lines = []
     for value in (-750, -500, -250, 250, 500, 750):
         helper_lines.append(
@@ -52,6 +56,8 @@ def build_sample_figure() -> go.Figure:
                 line=dict(color="#cbd5f5", width=1, dash="dot"),
             )
         )
+
+    # 背景を白で固定し、Legend を上部にまとめて UI と馴染ませる。
     fig.update_layout(
         plot_bgcolor="#ffffff",
         paper_bgcolor="#ffffff",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-
 Flask>=3.0
 plotly>=5.20
 playwright>=1.44
@@ -7,3 +6,4 @@ wxPython
 wxasync
 mike
 mkdocs-material
+pytest

--- a/templates/index.html
+++ b/templates/index.html
@@ -912,11 +912,14 @@
         </div>
       </div>
     </div>
+    <!-- アプリ全体のヘッダー領域 -->
     <header>
       <h1>TriOrb - SICK SLS Editor</h1>
     </header>
+    <!-- メインレイアウト: 左に Plotly 編集エリア、右に設定メニュー -->
     <main>
       <section class="content-area">
+        <!-- 図形の追加・保存などツール系 UI -->
         <div class="toolbar">
           <div class="toolbar-primary">
             <button id="btn-new" type="button">New</button>
@@ -954,6 +957,7 @@
           <div id="triorb-shape-checkboxes"></div>
         </div>
       </section>
+      <!-- サイドメニュー: XML 構造をツリー形式で表示 -->
       <aside class="side-menu">
         <h2>Structure Menu</h2>
         {% for item in menu_items %}

--- a/tests/playwright/test_shapes.py
+++ b/tests/playwright/test_shapes.py
@@ -3,6 +3,8 @@ import sys
 
 
 def run_playwright_test():
+    # Flask サーバーを別プロセスで起動している前提で、
+    # TriOrb のグローバル入力が Fieldset に伝播するかを最小限確認する。
     server_url = "http://127.0.0.1:5000/?debug=1"
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)
@@ -43,6 +45,7 @@ def run_playwright_test():
             "#btn-triorb-shape-uncheck-all",
         ]
         for selector in buttons:
+            # ボタン表示状態は UI の条件によって変わるため、存在チェックの上で順番にクリックする。
             if page.is_visible(selector):
                 page.click(selector)
                 page.wait_for_timeout(200)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,13 @@
+"""Flask アプリの最小限の起動確認テスト。"""
+
+from main import create_app
+
+
+def test_index_returns_ok():
+    """ルートパスにアクセスしたときに 200 が返ることを確認。"""
+    app = create_app()
+    client = app.test_client()
+
+    response = client.get("/")
+
+    assert response.status_code == 200


### PR DESCRIPTION
## 概要
- Flask アプリと Plotly 描画処理に日本語コメントを追加し、既存機能の挙動を整理
- pytest 用の軽量ユニットテストを追加し、Playwright テストにも補足コメントを記載
- README / Agent.md を最新構成へ更新し、Codespaces 手順と CI/CD 構成を追記
- GitHub Actions でテストと mike デプロイを自動実行するワークフローを作成

## テスト
- pytest（依存パッケージを取得できず失敗）


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69149fecd9d0832fae21a123a9ad9e4e)