### PR TITLE
Add failure notification to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,20 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Run pytest
+        id: run-pytest
         run: pytest --maxfail=1 --disable-warnings
+        continue-on-error: true
+      - name: Notify failure on pull requests
+        if: ${{ steps.run-pytest.outcome == 'failure' && github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '@codex 自動テストが失敗しました。ログを確認してください。'
+            })
+      - name: Fail workflow if pytest failed
+        if: ${{ steps.run-pytest.outcome == 'failure' }}
+        run: exit 1


### PR DESCRIPTION
## Summary
- add a GitHub Actions step that posts an `@codex` mention when pytest fails on pull requests
- ensure the workflow still fails the job after notifying of the failure

## Testing
- Not run (workflow-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916659be0f4832fade7c3817b270654)