### PR TITLE
Add documentation for Casetable Evals and FieldsConfiguration

### DIFF
--- a/Agent_Export-CasetablesAndCases_Casetable_Evals.md
+++ b/Agent_Export-CasetablesAndCases_Casetable_Evals.md
@@ -1,0 +1,26 @@
+# Export_CasetablesAndCases/Casetable/Evals の構成メモ
+
+## 概要
+- `Export_CasetablesAndCases` 配下の各 `Casetable` は、ひとつの `Evals` セクションを持ち、ここで評価ロジック（遮断パス）の一覧が定義される。サンプルでは 2 つの `Casetable` があり、1 件目は Eval×3（遮断パス1〜3）、2 件目は Eval×2（遮断パス4〜5）で構成されている。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L1959-L2665】【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L3527-L3598】
+- 各 `Eval` 要素には `Id` 属性が付与され、並列する子要素で名称や再起動条件、ケースの割り当てを明示する。同じ `FieldMode`／`UserFieldId` を参照することで、別 Casetable 間でも同一のフィールド構成を再利用できる。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L1960-L2186】【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L3528-L3589】
+
+## Eval 要素の定義
+| 子要素 | 役割 | 備考 |
+| --- | --- | --- |
+| `Name` | UI 表示用の遮断パス名。 | 例: 「遮断パス 1」〜「遮断パス 5」。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L1960-L2434】【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L3529-L3566】 |
+| `NameLatin9Key` | ラテン文字キー。多言語キーや内部識別子として利用。 | `_COPN01_8A74` など固有キーが並ぶ。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L1961-L2433】 |
+| `Q` | 遮断パス番号。 | 1〜5 が連番で入る。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L1962-L2433】【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L3531-L3566】 |
+| `Reset` | リセット条件をまとめたブロック。 | `ResetType`（例: `NoReset`）、`AutoResetTime`（秒単位）、`EvalResetSource`（制御名）がセットされる。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L1964-L1968】【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L3532-L3570】 |
+| `Cases` | 状態ごとのフィールド割り当て。 | 詳細は後述。`Case Id` ごとに `ScanPlanes/ScanPlane` をぶら下げる。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L1969-L2655】【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L3537-L3589】 |
+| `PermanentPreset` | 常時適用されるフィールドモード。 | 全 Eval が `FieldMode`=59 を参照し、警告/保護フィールドの固定モードを示す。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L2187-L2193】【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L3555-L3596】 |
+
+## Cases の構造
+- `Cases` は連番の `Case` 要素を束ね、各ケースでどの `UserField`（＝Fieldset/Field）を使うかを `ScanPlanes` 経由で指定する。
+  - サンプルの Casetable 0（Eval 1）では `Case Id="0"`〜`26` まで 27 通りを用意し、速度段や警告段に応じた `UserFieldId` をマッピングしている。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L1969-L2186】
+  - `Case` 直下の `ScanPlanes/ScanPlane` は監視面単位の設定で、`Id="1"` のスキャンプレーンに対して `UserFieldId` と `IsSplitted` フラグ（分割フィールドかどうか）を与える。`IsSplitted=true` は細分化された警告フィールド、`false` は通常フィールドを意味する。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L1970-L2105】【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L2440-L2649】
+  - Casetable 1 の Eval ではケース数が 2 件ずつで、いずれも `UserFieldId` 58/59/9/10 を割り当てており、簡易な切替ロジックになっている。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L3537-L3589】
+- `UserFieldId` と `FieldMode` は `FieldsConfiguration` 側の `UserField`／`StatFields` とリンクするため、Evals では「どのケースでどのフィールドをアクティブにするか」を宣言するのみで、幾何情報は保持しない。
+
+## PermanentPreset
+- 各 Eval 共通で `PermanentPreset/ScanPlanes/ScanPlane` を 1 件だけ持ち、そこに `FieldMode` を記述する。サンプルでは全て `59` で固定出力を指定しており、デバイス初期化時に参照する安全フィールドモードが定義されている。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L2187-L2193】【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L3555-L3596】
+

--- a/Agent_Export-CasetablesAndCases_Casetable_FieldsConfiguration.md
+++ b/Agent_Export-CasetablesAndCases_Casetable_FieldsConfiguration.md
@@ -1,0 +1,30 @@
+# Export_CasetablesAndCases/Casetable/FieldsConfiguration の構成メモ
+
+## 全体像
+- `FieldsConfiguration` は各 `Casetable` に 1 つ存在し、`Evals` から参照されるユーザーフィールド（可変フィールド）と統計フィールド（固定出力）を束ねる。`ScanPlanes` セクションで監視面とユーザーフィールド群を、`StatFields` セクションで出力固定値を宣言する構造になっている。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L2666-L3383】【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L3599-L4316】
+- サンプルでは 1 つのスキャンプレーン（Id=1, Name="Monitoring plane 1"）に 26 個の `UserFieldset` を割り当てており、Casetable 間で同一構成を共有している。これにより Evals では `UserFieldId` や `FieldMode` だけを指定すればよい。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L2668-L3375】【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L3600-L4308】
+
+## ScanPlanes / UserFieldsets
+- `ScanPlanes/ScanPlane` 直下には以下の要素が入る。
+  - `Index` / `Name`: スキャンプレーンの順序と表示名（例: Monitoring plane 1）。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L2668-L2671】【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L3600-L3604】
+  - `UserFieldsets`: フィールドセットのコレクション。Id=1〜26 が定義され、名称は方位＋距離（右0.65、前0.3 等）または役割（回転、Stop(minimum)）になっている。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L2672-L3374】【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L3605-L4307】
+- 各 `UserFieldset` の中身は共通のパターンで、以下のフィールドを持つ。
+  | 要素 | 説明 |
+  | --- | --- |
+  | `Index` / `Name` / `NameLatin9Key` | フィールドセットの順序、表示名、ラテンキー。例: `Index=0` / `Name=右0.65` / `NameLatin9Key=_FSN000_9516`。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L2672-L2704】 |
+  | `UserFields` | 単一または複数のフィールドを束ねる。ほとんどのセットは 2〜3 個（Protective, Speed down, Speed up）、`Stop(minimum)` などは 1 個のみ。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L2676-L3374】 |
+- `UserField` 要素の定義内容:
+  - `Id` と `Index`: Eval 側から参照されるユニーク ID と Fieldset 内での並び順。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L2676-L3374】
+  - `Name`: 役割名（Protective/Speed down/Speed up など）。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L2678-L3374】
+  - `FieldType`: 保護 (`ProtectiveSafeBlanking`) もしくは警告 (`WarningSafeBlanking`) の種別。ケースによっては Protective のみを持つ。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L2679-L3374】
+  - `MultipleSampling`: サンプリング数。通常は 2、停止最小値のみ 4。Evals 側では参照のみで変更しない。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L2681-L3374】
+  - `ObjectResolution`: 物体分解能。全フィールドで 70 を共有している。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L2682-L3374】
+  - `ContourNegative` / `ContourPositive`: 負/正側余白。サンプルはすべて 0 に揃っており、描画時にそのまま扱える。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L2683-L3374】
+
+## StatFields
+- `StatFields` には常時出力されるフィールド ID が定義され、`PermRed`（59）、`PermGreen`（60）、`PermGreenWf`（61）の 3 つが存在する。Evals 側の `PermanentPreset` から `FieldMode=59` が参照されるため、ここを基準に固定出力を切り替える。【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L3378-L3383】【F:sample/20251111-105839_ScannerDTM-Export.sgexml†L4311-L4316】
+
+## 実装時のポイント
+1. Evals で `UserFieldId` を追加する場合は、必ず `FieldsConfiguration` に同じ ID の `UserField` を先に定義する。
+2. スキャンプレーンを増やす場合は `FieldsConfiguration/ScanPlanes` を複数化し、それぞれに対応する `Cases/ScanPlane Id` を増やす。
+3. `StatFields` の ID を更新したら、`PermanentPreset` や関連する UI 定数も合わせて変更して整合性を保つ。


### PR DESCRIPTION
## Summary
- document the structure and definition of `Export_CasetablesAndCases/Casetable/Evals` based on the sample XML
- outline how `FieldsConfiguration` is organized, including scan planes, user fieldsets, and stat fields

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69167b8c8e44832fa1c7af9f156a695b)