### PR TITLE
Fix SpeedActivation serialization

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -6141,7 +6141,7 @@ function buildBaseSdImportExportLines({ scanDeviceAttrs = null, fieldsetDeviceAt
           const attrs = speedActivation.attributes || {};
           const attributeOrder = getAttributeOrder("SpeedActivation");
           const orderedKeys = [
-            ...attributeOrder,
+            ...attributeOrder.filter((key) => Object.prototype.hasOwnProperty.call(attrs, key)),
             ...Object.keys(attrs).filter((key) => !attributeOrder.includes(key)).sort(),
           ];
           const hasSimpleText =


### PR DESCRIPTION
## Summary
- ensure SpeedActivation serialization treats the Mode value as simple text when it is the only present attribute by filtering the attribute order list to actual attributes

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691800e950cc832fb56a7cb2e6de503a)