### PR TITLE
Add regression test for XML IO payloads

### DIFF
--- a/tests/data/io_expected.json
+++ b/tests/data/io_expected.json
@@ -1,0 +1,419 @@
+{
+  "menu_items": [
+    {
+      "tag": "FileInfo",
+      "summary": "No additional attributes"
+    },
+    {
+      "tag": "TriOrb_SICK_SLS_Editor",
+      "summary": "Source=TriOrb"
+    },
+    {
+      "tag": "Export_ScanPlanes",
+      "summary": "No additional attributes"
+    },
+    {
+      "tag": "Export_FieldsetsAndFields",
+      "summary": "No additional attributes"
+    },
+    {
+      "tag": "Export_CasetablesAndCases",
+      "summary": "No additional attributes"
+    }
+  ],
+  "fileinfo_fields": [
+    {
+      "tag": "ContentId",
+      "value": "Example Export"
+    },
+    {
+      "tag": "Company",
+      "value": "Example Corp"
+    },
+    {
+      "tag": "CreationToolVersion",
+      "value": "1.0"
+    }
+  ],
+  "root_attributes": {
+    "Version": "1.2",
+    "Timestamp": "2025-01-01T00:00:00Z"
+  },
+  "scan_planes": [
+    {
+      "attributes": {
+        "Index": "0",
+        "Name": "PlaneA",
+        "MultipleSampling": "2"
+      },
+      "devices": [
+        {
+          "attributes": {
+            "Index": "0",
+            "DeviceName": "DeviceA",
+            "Typekey": "NANS3"
+          }
+        }
+      ]
+    }
+  ],
+  "casetable_payload": {
+    "casetable_attributes": {
+      "Index": "0",
+      "Name": "Default"
+    },
+    "configuration": {
+      "tag": "Configuration",
+      "attributes": {},
+      "text": "",
+      "children": [
+        {
+          "tag": "ConfigItem",
+          "attributes": {
+            "Key": "Foo",
+            "Value": "Bar"
+          },
+          "text": "",
+          "children": []
+        }
+      ]
+    },
+    "cases": [
+      {
+        "attributes": {
+          "Index": "0",
+          "Name": "Case0"
+        },
+        "static_inputs": [
+          {
+            "attributes": {
+              "State": "High"
+            },
+            "value_key": "State"
+          }
+        ],
+        "speed_activation": {
+          "attributes": {
+            "Mode": "Off"
+          },
+          "mode_key": "Mode"
+        },
+        "layout": [
+          {
+            "kind": "static-inputs"
+          },
+          {
+            "kind": "speed-activation"
+          },
+          {
+            "kind": "node",
+            "node": {
+              "tag": "Extra",
+              "attributes": {
+                "Flag": "1"
+              },
+              "text": "",
+              "children": []
+            }
+          }
+        ]
+      }
+    ],
+    "evals": {
+      "attributes": {},
+      "evals": [
+        {
+          "attributes": {
+            "Index": "1",
+            "Priority": "Normal"
+          },
+          "name": "Eval One",
+          "nameLatin9Key": "_EVAL_1",
+          "q": "1",
+          "reset": {
+            "resetType": "NoReset",
+            "autoResetTime": "0",
+            "evalResetSource": "None"
+          },
+          "cases": [
+            {
+              "attributes": {
+                "Index": "0"
+              },
+              "scanPlane": {
+                "attributes": {
+                  "Axis": "X"
+                },
+                "userFieldId": "1",
+                "isSplitted": "false"
+              }
+            }
+          ],
+          "permanentPreset": {
+            "scanPlaneAttributes": {
+              "Orientation": "Horizontal"
+            },
+            "fieldMode": "59"
+          }
+        }
+      ]
+    },
+    "fields_configuration": {
+      "tag": "FieldsConfiguration",
+      "attributes": {
+        "Enabled": "true"
+      },
+      "text": "",
+      "children": [
+        {
+          "tag": "ScanPlanes",
+          "attributes": {},
+          "text": "",
+          "children": [
+            {
+              "tag": "ScanPlane",
+              "attributes": {
+                "Id": "1",
+                "Name": "Monitoring plane"
+              },
+              "text": "",
+              "children": [
+                {
+                  "tag": "UserFieldsets",
+                  "attributes": {},
+                  "text": "",
+                  "children": [
+                    {
+                      "tag": "UserFieldset",
+                      "attributes": {},
+                      "text": "",
+                      "children": [
+                        {
+                          "tag": "Index",
+                          "attributes": {},
+                          "text": "0",
+                          "children": []
+                        },
+                        {
+                          "tag": "Name",
+                          "attributes": {},
+                          "text": "SetA",
+                          "children": []
+                        },
+                        {
+                          "tag": "NameLatin9Key",
+                          "attributes": {},
+                          "text": "_SET_A",
+                          "children": []
+                        },
+                        {
+                          "tag": "UserFields",
+                          "attributes": {},
+                          "text": "",
+                          "children": [
+                            {
+                              "tag": "UserField",
+                              "attributes": {},
+                              "text": "",
+                              "children": [
+                                {
+                                  "tag": "Id",
+                                  "attributes": {},
+                                  "text": "1",
+                                  "children": []
+                                },
+                                {
+                                  "tag": "Index",
+                                  "attributes": {},
+                                  "text": "0",
+                                  "children": []
+                                },
+                                {
+                                  "tag": "Name",
+                                  "attributes": {},
+                                  "text": "Field A",
+                                  "children": []
+                                },
+                                {
+                                  "tag": "FieldType",
+                                  "attributes": {},
+                                  "text": "ProtectiveSafeBlanking",
+                                  "children": []
+                                },
+                                {
+                                  "tag": "MultipleSampling",
+                                  "attributes": {},
+                                  "text": "2",
+                                  "children": []
+                                },
+                                {
+                                  "tag": "ObjectResolution",
+                                  "attributes": {},
+                                  "text": "70",
+                                  "children": []
+                                },
+                                {
+                                  "tag": "ContourNegative",
+                                  "attributes": {},
+                                  "text": "0",
+                                  "children": []
+                                },
+                                {
+                                  "tag": "ContourPositive",
+                                  "attributes": {},
+                                  "text": "0",
+                                  "children": []
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "tag": "StatFields",
+          "attributes": {},
+          "text": "",
+          "children": [
+            {
+              "tag": "PermRed",
+              "attributes": {},
+              "text": "59",
+              "children": []
+            },
+            {
+              "tag": "PermGreen",
+              "attributes": {},
+              "text": "60",
+              "children": []
+            },
+            {
+              "tag": "PermGreenWf",
+              "attributes": {},
+              "text": "61",
+              "children": []
+            }
+          ]
+        }
+      ]
+    },
+    "layout": [
+      {
+        "kind": "configuration"
+      },
+      {
+        "kind": "cases"
+      },
+      {
+        "kind": "evals"
+      },
+      {
+        "kind": "fields_configuration"
+      }
+    ]
+  },
+  "fieldsets_payload": {
+    "devices": [
+      {
+        "attributes": {
+          "Index": "0",
+          "DeviceName": "DeviceA"
+        }
+      }
+    ],
+    "global_geometry": {
+      "Radius": "4"
+    },
+    "fieldsets": [
+      {
+        "attributes": {
+          "Index": "0",
+          "Name": "SetA"
+        },
+        "fields": [
+          {
+            "attributes": {
+              "Index": "0",
+              "Name": "Field A",
+              "Fieldtype": "ProtectiveSafeBlanking"
+            },
+            "shapeRefs": [
+              {
+                "shapeId": "shape-001"
+              }
+            ]
+          },
+          {
+            "attributes": {
+              "Index": "1",
+              "Name": "Field B",
+              "Fieldtype": "WarningSafeBlanking"
+            },
+            "shapeRefs": [
+              {
+                "shapeId": "shape-inline"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "triorb_shapes": [
+    {
+      "id": "shape-001",
+      "name": "Protective #1",
+      "type": "Polygon",
+      "fieldtype": "ProtectiveSafeBlanking",
+      "kind": "Field",
+      "polygon": {
+        "Type": "Field",
+        "points": [
+          {
+            "X": "0",
+            "Y": "0"
+          },
+          {
+            "X": "200",
+            "Y": "0"
+          },
+          {
+            "X": "200",
+            "Y": "100"
+          }
+        ]
+      }
+    },
+    {
+      "id": "shape-inline",
+      "name": "SetA Field B Polygon",
+      "type": "Polygon",
+      "fieldtype": "WarningSafeBlanking",
+      "kind": "CutOut",
+      "polygon": {
+        "Type": "CutOut",
+        "points": [
+          {
+            "X": "0",
+            "Y": "0"
+          },
+          {
+            "X": "1",
+            "Y": "0"
+          },
+          {
+            "X": "1",
+            "Y": "1"
+          }
+        ]
+      }
+    }
+  ],
+  "triorb_source": "TriOrb"
+}

--- a/tests/data/io_sample.sgexml
+++ b/tests/data/io_sample.sgexml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SdImportExport Version="1.2" Timestamp="2025-01-01T00:00:00Z">
+  <FileInfo>
+    <ContentId>Example Export</ContentId>
+    <Company>Example Corp</Company>
+    <CreationToolVersion>1.0</CreationToolVersion>
+  </FileInfo>
+  <TriOrb_SICK_SLS_Editor Source="TriOrb">
+    <Shapes>
+      <Shape ID="shape-001" Name="Protective #1" Type="Polygon" Fieldtype="ProtectiveSafeBlanking" Kind="Field">
+        <Polygon Type="Field">
+          <Point X="0" Y="0" />
+          <Point X="200" Y="0" />
+          <Point X="200" Y="100" />
+        </Polygon>
+      </Shape>
+    </Shapes>
+  </TriOrb_SICK_SLS_Editor>
+  <Export_ScanPlanes>
+    <ScanPlane Index="0" Name="PlaneA" MultipleSampling="2">
+      <Devices>
+        <Device Index="0" DeviceName="DeviceA" Typekey="NANS3" />
+      </Devices>
+    </ScanPlane>
+  </Export_ScanPlanes>
+  <Export_FieldsetsAndFields>
+    <ScanPlane Index="0" Name="PlaneA">
+      <Devices>
+        <Device Index="0" DeviceName="DeviceA" />
+      </Devices>
+      <GlobalGeometry Radius="4" />
+      <Fieldsets>
+        <Fieldset Index="0" Name="SetA">
+          <Field Index="0" Name="Field A" Fieldtype="ProtectiveSafeBlanking">
+            <Shapes>
+              <Shape ID="shape-001" />
+            </Shapes>
+          </Field>
+          <Field Index="1" Name="Field B" Fieldtype="WarningSafeBlanking">
+            <Polygon ID="shape-inline" Type="CutOut">
+              <Point X="0" Y="0" />
+              <Point X="1" Y="0" />
+              <Point X="1" Y="1" />
+            </Polygon>
+          </Field>
+        </Fieldset>
+      </Fieldsets>
+    </ScanPlane>
+  </Export_FieldsetsAndFields>
+  <Export_CasetablesAndCases>
+    <Casetable Index="0" Name="Default">
+      <Configuration>
+        <ConfigItem Key="Foo" Value="Bar" />
+      </Configuration>
+      <Cases>
+        <Case Index="0" Name="Case0">
+          <StaticInputs>
+            <StaticInput>
+              <State>High</State>
+            </StaticInput>
+          </StaticInputs>
+          <SpeedActivation Mode="Off" />
+          <Extra Flag="1" />
+        </Case>
+      </Cases>
+      <Evals>
+        <Eval Index="1" Priority="Normal">
+          <Name>Eval One</Name>
+          <NameLatin9Key>_EVAL_1</NameLatin9Key>
+          <Q>1</Q>
+          <Reset>
+            <ResetType>NoReset</ResetType>
+            <AutoResetTime>0</AutoResetTime>
+            <EvalResetSource>None</EvalResetSource>
+          </Reset>
+          <Cases>
+            <Case Index="0">
+              <ScanPlanes>
+                <ScanPlane Axis="X">
+                  <UserFieldId>1</UserFieldId>
+                  <IsSplitted>false</IsSplitted>
+                </ScanPlane>
+              </ScanPlanes>
+            </Case>
+          </Cases>
+          <PermanentPreset>
+            <ScanPlanes>
+              <ScanPlane Orientation="Horizontal">
+                <FieldMode>59</FieldMode>
+              </ScanPlane>
+            </ScanPlanes>
+          </PermanentPreset>
+        </Eval>
+      </Evals>
+      <FieldsConfiguration Enabled="true">
+        <ScanPlanes>
+          <ScanPlane Id="1" Name="Monitoring plane">
+            <UserFieldsets>
+              <UserFieldset>
+                <Index>0</Index>
+                <Name>SetA</Name>
+                <NameLatin9Key>_SET_A</NameLatin9Key>
+                <UserFields>
+                  <UserField>
+                    <Id>1</Id>
+                    <Index>0</Index>
+                    <Name>Field A</Name>
+                    <FieldType>ProtectiveSafeBlanking</FieldType>
+                    <MultipleSampling>2</MultipleSampling>
+                    <ObjectResolution>70</ObjectResolution>
+                    <ContourNegative>0</ContourNegative>
+                    <ContourPositive>0</ContourPositive>
+                  </UserField>
+                </UserFields>
+              </UserFieldset>
+            </UserFieldsets>
+          </ScanPlane>
+        </ScanPlanes>
+        <StatFields>
+          <PermRed>59</PermRed>
+          <PermGreen>60</PermGreen>
+          <PermGreenWf>61</PermGreenWf>
+        </StatFields>
+      </FieldsConfiguration>
+    </Casetable>
+  </Export_CasetablesAndCases>
+</SdImportExport>

--- a/tests/test_io_regression.py
+++ b/tests/test_io_regression.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import main
+
+_DATA_DIR = Path(__file__).parent / "data"
+_SAMPLE_XML = _DATA_DIR / "io_sample.sgexml"
+_EXPECTED_JSON = _DATA_DIR / "io_expected.json"
+
+
+def _collect_io_payloads() -> dict:
+    fieldsets_payload, triorb_shapes, triorb_source = main.load_fieldsets_and_shapes()
+    return {
+        "menu_items": main.load_menu_items(),
+        "fileinfo_fields": main.load_fileinfo_fields(),
+        "root_attributes": main.load_root_attributes(),
+        "scan_planes": main.load_scan_planes(),
+        "casetable_payload": main.load_casetable_payload(),
+        "fieldsets_payload": fieldsets_payload,
+        "triorb_shapes": triorb_shapes,
+        "triorb_source": triorb_source,
+    }
+
+
+def test_io_payloads_match_snapshot(monkeypatch):
+    monkeypatch.setattr(main, "SAMPLE_XML", _SAMPLE_XML)
+
+    actual = _collect_io_payloads()
+    expected = json.loads(_EXPECTED_JSON.read_text(encoding="utf-8"))
+
+    assert actual == expected


### PR DESCRIPTION
## Summary
- add a deterministic SdImportExport fixture along with the expected payload snapshot so that we can guard current IO formats
- add a pytest that loads the fixture, collects all Flask-facing payloads, and compares them against the golden snapshot

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918037099c4832fac3412e47a83eb4c)