### PR TITLE
Ensure min/max speed values are written to XML

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -4416,7 +4416,15 @@ function buildBaseSdImportExportLines({ scanDeviceAttrs = null, fieldsetDeviceAt
                 segment.node.tag === "Activation" &&
                 (caseData.staticInputsPlacement === "activation" ||
                   caseData.speedActivationPlacement === "activation")
-              ) {
+            ) {
+                childLines.push(
+                  ...buildActivationNodeLines(
+                    segment.node,
+                    caseData,
+                    indentLevel + 1
+                  )
+                );
+              } else if (segment.node.tag === "Activation") {
                 childLines.push(
                   ...buildActivationNodeLines(
                     segment.node,


### PR DESCRIPTION
## Summary
- always rebuild Activation nodes when saving cases so MinSpeed/MaxSpeed reflect the latest UI values even if the placements are not set to "activation"

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a6c23e8bc832faf1adfb71043c0d7)