### PR TITLE
Fix static asset URLs for frozen site

### DIFF
--- a/freeze.py
+++ b/freeze.py
@@ -3,8 +3,10 @@ from flask_frozen import Freezer
 from main import app
 
 # Flask アプリを静的 HTML に書き出す設定。
-# GitHub Pages へ公開するときに `docs/` 配下へ出力する想定。
+# GitHub Pages で `/<repo-name>/` 以下にホストされると `/static/...` のような
+# ルートパスが 404 になるため、相対 URL を生成するように設定する。
 app.config['FREEZER_DESTINATION'] = 'docs'
+app.config['FREEZER_RELATIVE_URLS'] = True
 freezer = Freezer(app)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- configure Flask-Frozen to emit relative URLs so that static assets resolve when hosted under a GitHub Pages subpath

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c981ca050832fb963a053ba92faa7)