### PR TITLE
Fix fieldset attribute updates in Structure Menu

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -4306,6 +4306,23 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
             </select>`;
         }
 
+        function updateFieldsetAttribute(fieldsetIndex, key, value) {
+          const fieldset = fieldsets[fieldsetIndex];
+          if (!fieldset) return;
+          fieldset.attributes = fieldset.attributes || {};
+          fieldset.attributes[key] = value;
+          if (key === "Name") {
+            const summary = document.querySelector(
+              `.fieldset-card[data-fieldset-index="${fieldsetIndex}"] .fieldset-summary`
+            );
+            if (summary) {
+              summary.textContent = value;
+            }
+          }
+          invalidateFieldsetTraces();
+          renderFigure();
+        }
+
         function updateFieldAttribute(fieldsetIndex, fieldIndex, key, value) {
           const fieldset = fieldsets[fieldsetIndex];
           const field = fieldset?.fields?.[fieldIndex];


### PR DESCRIPTION
## Summary
- add missing fieldset attribute handler so inputs like Name persist
- update fieldset summary text and refresh traces when fieldset attributes change

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692675962d2c832fae8b23765ae20e27)