### PR TITLE
Update default field names to Protective and Warning

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -341,6 +341,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const replicateTargetToggle = document.getElementById("replicate-target-toggle");
         const replicateCaseSelect = document.getElementById("replicate-case-select");
         const fieldTypeLabels = ["ProtectiveSafeBlanking", "WarningSafeBlanking"];
+        const defaultFieldNames = ["Protective", "Warning"];
         const createRectOriginXInput = document.getElementById("create-rect-originx");
         const createRectOriginYInput = document.getElementById("create-rect-originy");
         const createRectWidthInput = document.getElementById("create-rect-width");
@@ -1474,6 +1475,10 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
           return [];
         }
 
+        function getDefaultFieldName(index) {
+          return defaultFieldNames[index] || `Field ${index + 1}`;
+        }
+
         function initializeFieldsets(data) {
           if (!Array.isArray(data) || !data.length) {
             return [createDefaultFieldset(0)];
@@ -1489,12 +1494,12 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
                 Array.isArray(fieldset.fields) && fieldset.fields.length
                   ? fieldset.fields.map((field, fieldIndex) => ({
                       attributes: {
-                        Name: field.attributes?.Name || `Field ${fieldIndex + 1}`,
+                        Name: field.attributes?.Name || getDefaultFieldName(fieldIndex),
                         ...field.attributes,
                       },
                       shapeRefs: normalizeFieldShapeRefs(field),
                     }))
-                  : [createDefaultField(0)],
+                  : [createDefaultField(0), createDefaultField(1)],
               userVisible,
               visible: userVisible,
               forcedVisibleCount: 0,
@@ -1509,7 +1514,7 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
               Name: isFirst ? "Default" : `Fieldset ${index + 1}`,
               NameLatin9Key: `FS_DEFAULT_${index + 1}`,
             },
-            fields: [createDefaultField(0)],
+            fields: [createDefaultField(0), createDefaultField(1)],
             userVisible: true,
             visible: true,
             forcedVisibleCount: 0,
@@ -1561,10 +1566,11 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
           triorbShapes.push(newShape);
           registerTriOrbShapeInRegistry(newShape, triorbShapes.length - 1);
           invalidateTriOrbShapeCaches();
+          const fieldtype = fieldTypeLabels[index] || fieldTypeLabels[0];
           return {
             attributes: {
-              Name: `Field ${index + 1}`,
-              Fieldtype: "ProtectiveSafeBlanking",
+              Name: getDefaultFieldName(index),
+              Fieldtype: fieldtype,
               MultipleSampling: samplingValue,
               Resolution: "70",
               TolerancePositive: "0",
@@ -2687,7 +2693,7 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
             shapeKinds.forEach((kind) => {
               const shapeIds = Array.from(selection[kind] || []);
               const fieldName =
-                createFieldNameInputs[fieldIndex]?.value?.trim() || `Field ${fieldIndex + 1}`;
+                createFieldNameInputs[fieldIndex]?.value?.trim() || getDefaultFieldName(fieldIndex);
               const fieldType = fieldTypeLabels[fieldIndex] || fieldTypeLabels[0];
               entries.push({ fieldName, fieldType, shapeIds, kind });
             });
@@ -2710,7 +2716,7 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
               if (!shape) {
                 return;
               }
-              const fieldLabel = `${entry.fieldName || `Field ${entryIndex + 1}`} (${entry.fieldType})`;
+              const fieldLabel = `${entry.fieldName || getDefaultFieldName(entryIndex)} (${entry.fieldType})`;
               let trace = null;
               switch (shape.type) {
                 case "Rectangle":
@@ -2986,7 +2992,7 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
               const baseIndex = isAppendingToExisting
                 ? (targetFieldset?.fields?.length || 0) + index + 1
                 : index + 1;
-              input.value = `Field ${baseIndex}`;
+              input.value = getDefaultFieldName(baseIndex - 1);
             }
           });
           createFieldTypeSelects.forEach((select) => {
@@ -3046,7 +3052,7 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
               shapeIds.forEach((shapeId) => allShapeIds.push(shapeId));
             });
             const fieldName =
-              createFieldNameInputs[fieldIndex]?.value?.trim() || `Field ${fieldIndex + 1}`;
+              createFieldNameInputs[fieldIndex]?.value?.trim() || getDefaultFieldName(fieldIndex);
             entries.push({
               attributes: {
                 Name: fieldName,

--- a/templates/index.html
+++ b/templates/index.html
@@ -1657,10 +1657,10 @@
         </div>
         <div class="modal-section field-create-grid">
           <div class="field-create-column">
-            <h4>Field 1 (Protective)</h4>
+            <h4>Protective Field</h4>
             <label>
               Field Name
-              <input type="text" id="create-field-name-0" placeholder="Field 1 name" />
+              <input type="text" id="create-field-name-0" placeholder="Protective name" />
             </label>
             <div class="shape-list-group">
               <p>Type = Field</p>
@@ -1672,10 +1672,10 @@
             </div>
           </div>
           <div class="field-create-column">
-            <h4>Field 2 (Warning)</h4>
+            <h4>Warning Field</h4>
             <label>
               Field Name
-              <input type="text" id="create-field-name-1" placeholder="Field 2 name" />
+              <input type="text" id="create-field-name-1" placeholder="Warning name" />
             </label>
             <div class="shape-list-group">
               <p>Type = Field</p>

--- a/tests/test_field_defaults.py
+++ b/tests/test_field_defaults.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from main import create_app
+
+
+_JS_PATH = Path("static/js/app.js")
+
+
+def test_default_field_names_constant():
+    content = _JS_PATH.read_text(encoding="utf-8")
+    assert re.search(
+        r"defaultFieldNames\s*=\s*\[\s*\"Protective\"\s*,\s*\"Warning\"\s*\]",
+        content,
+    )
+
+
+def test_create_field_modal_default_labels():
+    app = create_app()
+    client = app.test_client()
+
+    response = client.get("/")
+    html = response.get_data(as_text=True)
+
+    assert "Protective Field" in html
+    assert "Warning Field" in html
+    assert 'placeholder="Protective name"' in html
+    assert 'placeholder="Warning name"' in html


### PR DESCRIPTION
## Summary
- set default field generation to use Protective/Warning labels and fieldtypes when creating new fieldsets
- update create field modal copy to reflect the new default field names
- add regression tests to pin the Protective/Warning defaults in the UI and JavaScript constants

## Testing
- pytest tests/test_field_defaults.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927c3fe5814832fb087e2ecc25f72a9)