### PR TITLE
Adjust SVG path parsing to avoid oversampling polygons

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -7396,14 +7396,13 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
               return { polygons: [], warnings: [] };
             }
 
-            const sampled = sampleSvgPathToPolygon(trimmed, pathWarnings);
-            if (sampled.length) {
-              return { polygons: sampled, warnings: Array.from(pathWarnings) };
+            const fallback = parseSvgPathToPolygonsLegacy(trimmed, pathWarnings);
+            if (fallback.polygons.length) {
+              return { polygons: fallback.polygons, warnings: Array.from(pathWarnings) };
             }
 
-            const fallback = parseSvgPathToPolygonsLegacy(trimmed, pathWarnings);
-            const mergedWarnings = new Set([...pathWarnings, ...fallback.warnings]);
-            return { polygons: fallback.polygons, warnings: Array.from(mergedWarnings) };
+            const sampled = sampleSvgPathToPolygon(trimmed, pathWarnings);
+            return { polygons: sampled, warnings: Array.from(pathWarnings) };
           }
 
           function sampleSvgPathToPolygon(d, pathWarnings) {


### PR DESCRIPTION
## Summary
- parse SVG paths with the existing command-based parser before falling back to sampled approximation
- keep sampling as a fallback while preserving collected warnings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929333ff480832f8e5fe83ba12a8fa4)