### PR TITLE
npm セットアップファイルを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ TriOrb メニュー、Structure メニュー、Plotly 上の図形・扇形表�
    ```
 3. http://localhost:5000/ または http://127.0.0.1:5000/ をブラウザで開いて UI を確認します。
 
+`npm install` で `package.json` の npm スクリプトが利用できるようになります。セットアップを自動化したい場合は以下を実行して venv 作成・依存関係インストール・Playwright ブラウザの準備をまとめて行えます。
+
+```bash
+npm run setup
+```
+
 `run_playwright.ps1` を使えば PowerShell（.venv 内）から Flask サーバーの起動と Playwright テストの実行をまとめて行えます。実行には `domains` の実行ポリシーを `RemoteSigned` など適切に設定してください。
 
 ### 依存ライブラリ補足

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sick-sls-editor",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Helper scripts for the SICK SLS Editor Flask/Plotly tooling.",
+  "license": "Apache-2.0",
+  "scripts": {
+    "setup": "bash run/setup.sh",
+    "start": "python main.py",
+    "test": "pytest",
+    "test:playwright": "python tests/playwright/test_shapes.py",
+    "playwright:install": "python -m playwright install chromium"
+  }
+}

--- a/run/setup.sh
+++ b/run/setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+project_root="$(cd -- "${script_dir}/.." && pwd)"
+cd "$project_root"
+
+python_bin="${PYTHON_BIN:-python3}"
+if ! command -v "$python_bin" >/dev/null 2>&1; then
+  python_bin="python"
+fi
+
+venv_dir="${VENV_DIR:-.venv}"
+if [ ! -d "$venv_dir" ]; then
+  echo "Creating virtual environment at ${venv_dir}..."
+  "$python_bin" -m venv "$venv_dir"
+fi
+
+# shellcheck source=/dev/null
+source "${venv_dir}/bin/activate"
+
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+python -m playwright install chromium
+
+echo "Setup completed. Activate the environment with 'source ${venv_dir}/bin/activate' before running npm scripts or python commands."


### PR DESCRIPTION
## 概要
- npm スクリプトをまとめた package.json を追加し、サーバー起動やテストを npm 経由でも呼び出せるようにしました
- Python 依存と Playwright ブラウザ準備を自動化する run/setup.sh を追加しました
- README にセットアップスクリプトの実行手順を追記しました

## テスト
- テスト未実行（セットアップスクリプトの追加のみ）

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692aba764c14832fb8939933eb5dddbb)