### PR TITLE
Fix TriOrb save/load and modal interactions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,12 +7,12 @@
 - モーダル: +Shape / +Field で Shape/Fieldset を登録する際は、モーダルで Fieldset チェックをトグル形式に変更済、Cancel で元に戻る・モーダルはドラッグ/リサイズ可能・削除ボタンは編集モードのみ表示。
 - ファイル読み書きは今後確認不要（承認済）なので、必要に応じて `python main.py` や Playwright 実行で上書き・保存してよい。
 - `<SdImportExport>` 以下の構造は変更しない。TriOrb 情報は `<TriOrb_SICK_SLS_Editor>` に格納し、それ以外のセクションと混在させない。Load 時には TriOrb メタ情報で形式を判別する。
-- コード変更時は必ずブラウザで起動し、コンソールにエラーが出ていないことを確認する（`renderFieldsets`/`renderFigure` 周りで録画され続ける mis-synced trace がないか検証）。
+- コード変更時は必ずローカル Flask を起動してブラウザで確認し、その後 Playwright でも確認する。少なくとも `run_playwright.ps1` か、`python -u -c "from main import create_app; create_app().run(port=5001)"` を別端末で起動したうえで `python tests/playwright/test_shapes.py` を実行し、コンソールエラーがないことを確認する（`renderFieldsets`/`renderFigure` 周りで mis-synced trace が残らないか検証）。
 - ./docs以下をAgentや手動で編集することはなく、mike deployを通じてのみ編集します
 
 ## テスト & 手動確認
 - ユニット: `pytest`
-- Playwright: `run_playwright.ps1` または `python tests/playwright/test_shapes.py`（PowerShell では DB・browser install などを先に行う）。Playwright は `?debug=1` で TriOrb UI を展開し `global-multiple-sampling` 等の入力待ちの状態までカバーする。
+- Playwright: 原則としてローカル Flask を起動した状態で確認する。標準手順は `run_playwright.ps1`。手動で行う場合は `python -u -c "from main import create_app; create_app().run(port=5001)"` を起動し、別端末で `python tests/playwright/test_shapes.py` を実行する。Playwright は `?debug=1` で TriOrb UI を展開し `global-multiple-sampling` 等の入力待ちの状態までカバーする。
 - 手動: `TestMatrix.md` に書き起こされたチェック項目（TriOrb Shapes 編集、Fieldset/Shape トグル、Save 形式 1/2、Device 別ファイル出力など）を走らせる。
 
 ## CI / デプロイ
@@ -21,7 +21,7 @@
 
 ## 直近の留意事項
 - `TriOrb Shapes` / `Fieldsets` / `Devices` は JS 側の同期が肝。Shape 編集後 `renderTriOrbShapes()`→`renderFieldsets()`→`renderFigure()` までの再描画が行われて console が silent になることを確認。
-- PowerShell スクリプト `run_playwright.ps1` は既に存在し、サーバー起動と Playwright テストを連続実行する。必要なら `Set-ExecutionPolicy RemoteSigned` を実行しておく。
+- PowerShell スクリプト `run_playwright.ps1` はローカル Flask を `127.0.0.1:5001` で起動してから Playwright を流す。必要なら `Set-ExecutionPolicy RemoteSigned` を実行しておく。
 - TriOrb モーダルでは、Fieldset チェックのトグル化とモーダルのドラッグ/リサイズ、Add/Edit/Delete の区別、Cancel での値リセットが揃っていることを確認する。
 - `README.md` を常に最新化して、Playwright 実行手順や `pip install -r requirements.txt` などのセットアップを明文化する。これらが現場のドキュメントとなる。
 - +Field モーダル: Protective/Warning の Field 内で Type=Field/CutOut ごとの Shape 選択と Plotly プレビュー、OK/Cancel で Fieldset を保存/破棄できる UI を導入しました。

--- a/run_playwright.ps1
+++ b/run_playwright.ps1
@@ -1,23 +1,49 @@
 param(
-    [int]$WaitSeconds = 4
+    [int]$WaitSeconds = 15,
+    [int]$Port = 5001
 )
 
 function Stop-Server([System.Diagnostics.Process]$server) {
     if ($server -and !$server.HasExited) {
         Write-Host "Stopping Flask server (PID $($server.Id))..."
-        $server | Stop-Process -Force
+        Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue
+    }
+    Get-CimInstance Win32_Process -Filter "Name = 'python.exe'" -ErrorAction SilentlyContinue |
+        Where-Object { $_.CommandLine -like '*create_app().run(port=*' -and $_.CommandLine -like '*main*' } |
+        ForEach-Object {
+            Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
+        }
+}
+
+function Test-PortOpen {
+    param(
+        [string]$TargetHost = '127.0.0.1',
+        [int]$Port
+    )
+    $client = New-Object System.Net.Sockets.TcpClient
+    try {
+        $async = $client.BeginConnect($TargetHost, $Port, $null, $null)
+        $success = $async.AsyncWaitHandle.WaitOne(1000, $false)
+        if (-not $success) {
+            return $false
+        }
+        $client.EndConnect($async) | Out-Null
+        return $true
+    } catch {
+        return $false
+    } finally {
+        $client.Close()
     }
 }
 
 function Wait-ForServer {
     param(
-        [int]$Port = 5000,
+        [int]$Port = 5001,
         [int]$TimeoutSeconds = 10
     )
     $sw = [diagnostics.stopwatch]::StartNew()
     while ($sw.Elapsed.TotalSeconds -lt $TimeoutSeconds) {
-        $test = Test-NetConnection -ComputerName '127.0.0.1' -Port $Port -WarningAction SilentlyContinue
-        if ($test.TcpTestSucceeded) {
+        if (Test-PortOpen -TargetHost '127.0.0.1' -Port $Port) {
             return $true
         }
         Start-Sleep -Seconds 1
@@ -26,14 +52,17 @@ function Wait-ForServer {
 }
 
 Write-Host "Starting Flask server..."
-$serverProcess = Start-Process -FilePath "python" -ArgumentList "main.py" -PassThru
+$serverArgs = '-u', '-c', "from main import create_app; create_app().run(port=$Port)"
+$serverProcess = Start-Process -FilePath "python" -ArgumentList $serverArgs -WorkingDirectory $PSScriptRoot -PassThru
 try {
     Write-Host "Waiting for server to accept connections..."
-    if (-not (Wait-ForServer -Port 5000 -TimeoutSeconds $WaitSeconds)) {
-        throw "Flask server did not become ready within $WaitSeconds seconds."
+    if (-not (Wait-ForServer -Port $Port -TimeoutSeconds $WaitSeconds)) {
+        throw "Flask server did not become ready within $WaitSeconds seconds on port $Port."
     }
     Write-Host "Running Playwright test..."
-    $exitCode = & python "tests/playwright/test_shapes.py"
+    $env:PLAYWRIGHT_SERVER_URL = "http://127.0.0.1:$Port/?debug=1"
+    & python "tests/playwright/test_shapes.py"
+    $exitCode = $LASTEXITCODE
     if ($exitCode -ne 0) {
         throw "Playwright test failed with exit code $exitCode."
     }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -19,6 +19,7 @@ import {
   getPolygonTypeValue,
   initializeTriOrbShapes,
   parsePolygonPoints,
+  sanitizeLoadedShapeName,
   setPolygonTypeValue,
 } from "./modules/triorbData.js";
 
@@ -239,6 +240,10 @@ document.addEventListener("DOMContentLoaded", () => {
         const checkAllBtn = document.getElementById("btn-fieldset-check-all");
         const uncheckAllBtn = document.getElementById("btn-fieldset-uncheck-all");
         const fieldDeleteVisibleBtn = document.getElementById("btn-field-delete-visible");
+        const floatingPanelLauncherButtons = Array.from(
+          document.querySelectorAll(".panel-launch-btn[data-panel-target]")
+        );
+        const floatingPanels = Array.from(document.querySelectorAll(".floating-panel"));
         const toggleLegendBtn = document.getElementById("btn-toggle-legend");
         const fieldOfViewInput = document.getElementById("triorb-field-of-view");
         const globalResolutionInput = document.getElementById("global-resolution");
@@ -346,6 +351,13 @@ document.addEventListener("DOMContentLoaded", () => {
             return acc;
           }, {})
         );
+        const createFieldModalSelectionAnchors = createFieldShapeLists.map(() =>
+          shapeKinds.reduce((acc, kind) => {
+            acc[kind] = null;
+            return acc;
+          }, {})
+        );
+        let createShapeFieldsetSelectionAnchor = null;
         const replicateFieldsetSelect = document.getElementById("replicate-fieldset-select");
         const replicateCopyCountInput = document.getElementById("replicate-copy-count");
         const replicateOffsetXInput = document.getElementById("replicate-offset-x");
@@ -372,6 +384,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const replicateCaseSelect = document.getElementById("replicate-case-select");
         const fieldTypeLabels = ["ProtectiveSafeBlanking", "WarningSafeBlanking"];
         const defaultFieldNames = ["Protective", "Warning"];
+        const triOrbStateSnapshotVersion = 1;
         const createRectOriginXInput = document.getElementById("create-rect-originx");
         const createRectOriginYInput = document.getElementById("create-rect-originy");
         const createRectWidthInput = document.getElementById("create-rect-width");
@@ -397,7 +410,9 @@ document.addEventListener("DOMContentLoaded", () => {
         let pendingSvgImportContext = null;
         let triorbSource = bootstrapData.triorbSource || "";
         let fieldsets = initializeFieldsets(initialFieldsets);
-        let fieldsetDevices = initializeFieldsetDevices(initialFieldsetDevices);
+        let fieldsetDevices = initializeFieldsetDevices(initialFieldsetDevices, {
+          supplementDefaults: true,
+        });
         let fieldsetGlobalGeometry = initializeGlobalGeometry(initialFieldsetGlobal);
         const casetableCasesLimit = 128;
         const casetableEvalsLimit = 5;
@@ -464,6 +479,8 @@ document.addEventListener("DOMContentLoaded", () => {
         let createShapePreview = null;
         let createShapeDraftId = null;
         let fieldModalPreview = null;
+        let floatingPanelZCounter = 60;
+        let floatingPanelDragState = null;
         updateGlobalFieldAttributes();
 
         let lastHoverPoint = null;
@@ -557,6 +574,188 @@ document.addEventListener("DOMContentLoaded", () => {
           const resolvedState =
             typeof state === "string" ? state : state ? "error" : "ok";
           statusText.dataset.state = resolvedState;
+        }
+
+        function captureFileInfoValues() {
+          const scope = document.querySelector('[data-scope="fileinfo"]');
+          if (!scope) {
+            return {};
+          }
+          return Array.from(
+            scope.querySelectorAll(".menu-fileinfo-field input, .menu-fileinfo-field textarea")
+          ).reduce((acc, input) => {
+            const tag = input.dataset.field || sanitizeTagName(input.id || "Field");
+            acc[tag] = input.value ?? "";
+            return acc;
+          }, {});
+        }
+
+        function applyFileInfoValues(values = {}) {
+          const scope = document.querySelector('[data-scope="fileinfo"]');
+          if (!scope) {
+            return;
+          }
+          Array.from(
+            scope.querySelectorAll(".menu-fileinfo-field input, .menu-fileinfo-field textarea")
+          ).forEach((input) => {
+            const tag = input.dataset.field || sanitizeTagName(input.id || "Field");
+            if (Object.prototype.hasOwnProperty.call(values, tag)) {
+              input.value = values[tag] ?? "";
+            }
+          });
+        }
+
+        function encodeBase64Unicode(value) {
+          const encoder = new TextEncoder();
+          const bytes = encoder.encode(String(value ?? ""));
+          let binary = "";
+          bytes.forEach((byte) => {
+            binary += String.fromCharCode(byte);
+          });
+          return btoa(binary);
+        }
+
+        function decodeBase64Unicode(value) {
+          const binary = atob(String(value ?? ""));
+          const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+          const decoder = new TextDecoder();
+          return decoder.decode(bytes);
+        }
+
+        function clampValue(value, min, max) {
+          return Math.min(max, Math.max(min, value));
+        }
+
+        function syncFloatingPanelLauncherStates() {
+          floatingPanelLauncherButtons.forEach((button) => {
+            const target = document.getElementById(button.dataset.panelTarget || "");
+            const isActive = Boolean(target?.classList.contains("active"));
+            button.classList.toggle("active", isActive);
+            button.setAttribute("aria-pressed", String(isActive));
+          });
+        }
+
+        function bringFloatingPanelToFront(panel) {
+          if (!panel) {
+            return;
+          }
+          floatingPanelZCounter += 1;
+          panel.style.zIndex = String(floatingPanelZCounter);
+        }
+
+        function constrainFloatingPanelToViewport(panel) {
+          if (!panel) {
+            return;
+          }
+          const rect = panel.getBoundingClientRect();
+          const maxLeft = Math.max(16, window.innerWidth - rect.width - 16);
+          const maxTop = Math.max(16, window.innerHeight - rect.height - 16);
+          const left = clampValue(Number.parseFloat(panel.style.left) || rect.left, 16, maxLeft);
+          const top = clampValue(Number.parseFloat(panel.style.top) || rect.top, 16, maxTop);
+          panel.style.left = `${left}px`;
+          panel.style.top = `${top}px`;
+          panel.style.right = "auto";
+        }
+
+        function ensureFloatingPanelPosition(panel) {
+          if (!panel) {
+            return;
+          }
+          if (panel.dataset.positioned === "true") {
+            constrainFloatingPanelToViewport(panel);
+            return;
+          }
+          const panelIndex = Math.max(0, floatingPanels.indexOf(panel));
+          const column = panelIndex % 2;
+          const row = Math.floor(panelIndex / 2);
+          const rect = panel.getBoundingClientRect();
+          const width = rect.width || 560;
+          const left = Math.max(
+            16,
+            window.innerWidth - width - 24 - column * 28
+          );
+          const top = 112 + row * 28;
+          panel.style.left = `${left}px`;
+          panel.style.top = `${top}px`;
+          panel.style.right = "auto";
+          panel.dataset.positioned = "true";
+          constrainFloatingPanelToViewport(panel);
+        }
+
+        function openFloatingPanel(panelId) {
+          const panel = document.getElementById(panelId || "");
+          if (!panel) {
+            return;
+          }
+          panel.classList.add("active");
+          bringFloatingPanelToFront(panel);
+          ensureFloatingPanelPosition(panel);
+          syncFloatingPanelLauncherStates();
+        }
+
+        function closeFloatingPanel(target) {
+          const panel =
+            typeof target === "string" ? document.getElementById(target) : target;
+          if (!panel) {
+            return;
+          }
+          panel.classList.remove("active");
+          syncFloatingPanelLauncherStates();
+        }
+
+        function toggleFloatingPanel(panelId) {
+          const panel = document.getElementById(panelId || "");
+          if (!panel) {
+            return;
+          }
+          if (panel.classList.contains("active")) {
+            closeFloatingPanel(panel);
+          } else {
+            openFloatingPanel(panelId);
+          }
+        }
+
+        function handleFloatingPanelPointerDown(event) {
+          const header = event.target.closest("[data-panel-drag-handle]");
+          if (!header) {
+            return;
+          }
+          const panel = header.closest(".floating-panel");
+          if (!panel) {
+            return;
+          }
+          bringFloatingPanelToFront(panel);
+          ensureFloatingPanelPosition(panel);
+          const rect = panel.getBoundingClientRect();
+          floatingPanelDragState = {
+            panel,
+            pointerId: event.pointerId,
+            offsetX: event.clientX - rect.left,
+            offsetY: event.clientY - rect.top,
+          };
+          header.setPointerCapture?.(event.pointerId);
+          event.preventDefault();
+        }
+
+        function handleFloatingPanelPointerMove(event) {
+          if (!floatingPanelDragState || floatingPanelDragState.pointerId !== event.pointerId) {
+            return;
+          }
+          const { panel, offsetX, offsetY } = floatingPanelDragState;
+          panel.style.left = `${event.clientX - offsetX}px`;
+          panel.style.top = `${event.clientY - offsetY}px`;
+          panel.style.right = "auto";
+          panel.dataset.positioned = "true";
+          constrainFloatingPanelToViewport(panel);
+        }
+
+        function handleFloatingPanelPointerUp(event) {
+          if (!floatingPanelDragState || floatingPanelDragState.pointerId !== event.pointerId) {
+            return;
+          }
+          const activePanel = floatingPanelDragState.panel;
+          floatingPanelDragState = null;
+          constrainFloatingPanelToViewport(activePanel);
         }
 
         function invalidateBaseFigureTraces() {
@@ -3044,11 +3243,38 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
           if (!selection) {
             return;
           }
-          if (selection.has(shapeId)) {
-            selection.delete(shapeId);
-          } else {
-            selection.add(shapeId);
+          const list = createFieldShapeLists[fieldIndex]?.[kind];
+          const anchorShapeId = createFieldModalSelectionAnchors[fieldIndex]?.[kind] || null;
+          const nextState = !selection.has(shapeId);
+          if (event.shiftKey && list && anchorShapeId) {
+            const buttons = Array.from(list.querySelectorAll(".create-field-shape-btn"));
+            const anchorIndex = buttons.findIndex((entry) => entry.dataset.shapeId === anchorShapeId);
+            const currentIndex = buttons.findIndex((entry) => entry.dataset.shapeId === shapeId);
+            if (anchorIndex >= 0 && currentIndex >= 0) {
+              const start = Math.min(anchorIndex, currentIndex);
+              const end = Math.max(anchorIndex, currentIndex);
+              buttons.slice(start, end + 1).forEach((entry) => {
+                const rangeShapeId = entry.dataset.shapeId;
+                if (!rangeShapeId) {
+                  return;
+                }
+                if (nextState) {
+                  selection.add(rangeShapeId);
+                } else {
+                  selection.delete(rangeShapeId);
+                }
+              });
+              setCreateFieldShapeSelections(fieldIndex, kind, Array.from(selection));
+              createFieldModalSelectionAnchors[fieldIndex][kind] = shapeId;
+              return;
+            }
           }
+          if (nextState) {
+            selection.add(shapeId);
+          } else {
+            selection.delete(shapeId);
+          }
+          createFieldModalSelectionAnchors[fieldIndex][kind] = shapeId;
           const isActive = selection.has(shapeId);
           button.classList.toggle("active", isActive);
           button.setAttribute("aria-pressed", String(isActive));
@@ -3393,6 +3619,11 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
               selection[kind]?.clear();
             });
           });
+          createFieldModalSelectionAnchors.forEach((selection) => {
+            shapeKinds.forEach((kind) => {
+              selection[kind] = null;
+            });
+          });
           renderCreateFieldShapeLists();
           if (createFieldModalTitle) {
             createFieldModalTitle.textContent = isAppendingToExisting ? "Add Field" : "Add Fieldset";
@@ -3410,6 +3641,11 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
           createFieldModalFieldShapeSelections.forEach((_, fieldIndex) => {
             shapeKinds.forEach((kind) => {
               setCreateFieldShapeSelections(fieldIndex, kind, []);
+            });
+          });
+          createFieldModalSelectionAnchors.forEach((selection) => {
+            shapeKinds.forEach((kind) => {
+              selection[kind] = null;
             });
           });
           createFieldTargetFieldsetIndex = null;
@@ -4313,7 +4549,7 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
             `${shapeType} Shape ${triorbShapes.length + 1}`;
           const shape = createDefaultTriOrbShape(triorbShapes.length, shapeType);
           shape.id = normalizedAttrs.ID || createShapeId();
-          shape.name = shapeName;
+          shape.name = sanitizeLoadedShapeName(shapeName, shapeType);
           shape.fieldtype = context.fieldtype || shape.fieldtype;
           if (shapeType === "Polygon") {
             shape.polygon = {
@@ -5237,35 +5473,34 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
             .join("");
         }
 
-        function initializeFieldsetDevices(data) {
-          let devices;
+        function initializeFieldsetDevices(
+          data,
+          { supplementDefaults = false } = {}
+        ) {
           if (!Array.isArray(data) || !data.length) {
-            devices = getDefaultFieldsetDevices();
-          } else {
-            devices = data.map((device, index) => {
-              const attrs = { ...(device.attributes || {}) };
-              if (!attrs.DeviceName) {
-                const scanDeviceByName = findScanPlaneDeviceByName(attrs.DeviceName);
-                if (scanDeviceByName?.attributes?.DeviceName) {
-                  attrs.DeviceName = scanDeviceByName.attributes.DeviceName;
-                } else {
-                  const scanDevice = findScanPlaneDeviceByTypekey(attrs.Typekey);
-                  if (scanDevice?.attributes?.DeviceName) {
-                    attrs.DeviceName = scanDevice.attributes.DeviceName;
-                  } else {
-                    attrs.DeviceName = `Device ${index + 1}`;
-                  }
-                }
-              }
-              const wrapper = { attributes: attrs };
-              applyScanPlaneDeviceAttributes(wrapper, {
-                deviceName: attrs.DeviceName,
-                typekey: attrs.Typekey,
-              });
-              return wrapper;
-            });
+            return getDefaultFieldsetDevices();
           }
-          ensureDefaultFieldsetDevices(devices);
+          const devices = data.map((device, index) => {
+            const attrs = { ...(device.attributes || {}) };
+            if (!attrs.DeviceName) {
+              const scanDevice = (scanPlanes[0]?.devices || [])[index] ||
+                findScanPlaneDeviceByTypekey(attrs.Typekey);
+              if (scanDevice?.attributes?.DeviceName) {
+                attrs.DeviceName = scanDevice.attributes.DeviceName;
+              } else {
+                attrs.DeviceName = `Device ${index + 1}`;
+              }
+            }
+            const wrapper = { attributes: attrs };
+            applyScanPlaneDeviceAttributes(wrapper, {
+              deviceName: attrs.DeviceName,
+              typekey: attrs.Typekey,
+            });
+            return wrapper;
+          });
+          if (supplementDefaults) {
+            ensureDefaultFieldsetDevices(devices);
+          }
           return devices;
         }
 
@@ -5289,6 +5524,137 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
             text: typeof node.text === "string" ? node.text : "",
             children,
           };
+        }
+
+        function captureTriOrbStateSnapshot() {
+          return {
+            version: triOrbStateSnapshotVersion,
+            rootAttributes: { ...(rootAttributes || {}) },
+            fileInfo: captureFileInfoValues(),
+            scanPlanes: JSON.parse(JSON.stringify(scanPlanes || [])),
+            triorbShapes: JSON.parse(JSON.stringify(triorbShapes || [])),
+            triorbSource: triorbSource || "TriOrb",
+            fieldsets: JSON.parse(JSON.stringify(fieldsets || [])),
+            fieldsetDevices: JSON.parse(JSON.stringify(fieldsetDevices || [])),
+            fieldsetGlobalGeometry: JSON.parse(JSON.stringify(fieldsetGlobalGeometry || {})),
+            casetableAttributes: cloneAttributes(casetableAttributes || {}),
+            casetableConfiguration: cloneGenericNode(casetableConfiguration),
+            casetableCases: JSON.parse(JSON.stringify(casetableCases || [])),
+            casetableLayout: JSON.parse(JSON.stringify(casetableLayout || [])),
+            casetableEvals: JSON.parse(JSON.stringify(casetableEvals || null)),
+            fieldOfViewDegrees,
+            globalMultipleSampling,
+            globalResolution,
+            globalTolerancePositive,
+            globalToleranceNegative,
+            legendVisible,
+            caseToggleStates: Array.isArray(caseToggleStates) ? [...caseToggleStates] : [],
+            currentFigure: cloneFigure(currentFigure || defaultFigure),
+          };
+        }
+
+        function applySnapshotGlobals(snapshot = {}) {
+          fieldOfViewDegrees = parseNumeric(snapshot.fieldOfViewDegrees, 270);
+          globalMultipleSampling = String(
+            snapshot.globalMultipleSampling ?? deriveInitialMultipleSampling(fieldsets) ?? "2"
+          );
+          globalResolution = parseNumeric(
+            snapshot.globalResolution,
+            deriveFieldAttribute(fieldsets, "Resolution", 70)
+          );
+          globalTolerancePositive = parseNumeric(
+            snapshot.globalTolerancePositive,
+            deriveFieldAttribute(fieldsets, "TolerancePositive", 0)
+          );
+          globalToleranceNegative = parseNumeric(
+            snapshot.globalToleranceNegative,
+            deriveFieldAttribute(fieldsets, "ToleranceNegative", 0)
+          );
+          legendVisible = snapshot.legendVisible !== false;
+          if (fieldOfViewInput) {
+            fieldOfViewInput.value = String(fieldOfViewDegrees);
+          }
+          if (globalMultipleSamplingInput) {
+            globalMultipleSamplingInput.value = String(globalMultipleSampling);
+          }
+          if (globalResolutionInput) {
+            globalResolutionInput.value = String(globalResolution);
+          }
+          if (globalTolerancePositiveInput) {
+            globalTolerancePositiveInput.value = String(globalTolerancePositive);
+          }
+          if (globalToleranceNegativeInput) {
+            globalToleranceNegativeInput.value = String(globalToleranceNegative);
+          }
+          if (toggleLegendBtn) {
+            toggleLegendBtn.textContent = legendVisible ? "Hide Legend" : "Show Legend";
+          }
+          applyGlobalMultipleSampling(globalMultipleSampling, { rerender: false });
+          updateGlobalFieldAttributes();
+        }
+
+        function restoreTriOrbStateSnapshot(snapshot = {}) {
+          applyFileInfoValues(snapshot.fileInfo || {});
+          scanPlanes = initializeScanPlanes(snapshot.scanPlanes);
+          triorbShapes = initializeTriOrbShapes(snapshot.triorbShapes);
+          triorbSource = snapshot.triorbSource || "TriOrb";
+          triOrbImportContext = { triOrbRootFound: true, restoredFromSnapshot: true };
+          rebuildTriOrbShapeRegistry();
+          triOrbShapeCardCache.clear();
+          triOrbShapesListInitialized = false;
+          fieldsets = initializeFieldsets(snapshot.fieldsets);
+          fieldsetDevices = initializeFieldsetDevices(snapshot.fieldsetDevices, {
+            supplementDefaults: false,
+          });
+          fieldsetGlobalGeometry = initializeGlobalGeometry(snapshot.fieldsetGlobalGeometry);
+          casetableAttributes = cloneAttributes(snapshot.casetableAttributes || { Index: "0" });
+          casetableConfiguration = normalizeCasetableConfiguration(snapshot.casetableConfiguration);
+          casetableCases = initializeCasetableCases(snapshot.casetableCases);
+          casetableLayout = normalizeCasetableLayout(snapshot.casetableLayout);
+          casetableEvals = normalizeCasetableEvals(snapshot.casetableEvals, casetableCases.length);
+          casetableFieldsConfiguration = null;
+          caseToggleStates =
+            Array.isArray(snapshot.caseToggleStates) &&
+            snapshot.caseToggleStates.length === casetableCases.length
+              ? snapshot.caseToggleStates.map(Boolean)
+              : casetableCases.map(() => false);
+          applySnapshotGlobals(snapshot);
+          currentFigure = snapshot.currentFigure
+            ? cloneFigure(snapshot.currentFigure)
+            : cloneFigure(defaultFigure);
+          invalidateBaseFigureTraces();
+          invalidateDeviceTraceCache();
+          invalidateFieldsetTraces();
+          invalidateTriOrbShapeCaches();
+          renderScanPlanes();
+          renderFieldsetDevices();
+          renderFieldsetGlobal();
+          renderTriOrbShapes();
+          renderTriOrbShapeCheckboxes();
+          renderFieldsets();
+          renderCasetableConfiguration();
+          renderCasetableCases();
+          renderCasetableEvals();
+          regenerateFieldsConfiguration();
+          renderCasetableFieldsConfiguration();
+          refreshCaseFieldAssignments({ rerenderCaseToggles: true, rerenderFigure: false });
+          renderCaseCheckboxes();
+          renderFieldsetCheckboxes();
+        }
+
+        function readTriOrbStateSnapshot(triOrbNode) {
+          if (!triOrbNode) {
+            return null;
+          }
+          const snapshotNode = findFirstByTag(triOrbNode, "StateSnapshot");
+          const payload = (snapshotNode?.textContent || "").trim();
+          if (!snapshotNode || !payload) {
+            return null;
+          }
+          const encoding = (snapshotNode.getAttribute("Encoding") || "base64").toLowerCase();
+          const decoded =
+            encoding === "base64" ? decodeBase64Unicode(payload) : payload;
+          return JSON.parse(decoded);
         }
 
         function normalizeCasetableConfiguration(node) {
@@ -6481,6 +6847,9 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
           const lines = buildBaseSdImportExportLines({
             deviceIndexStrategy: "sequential",
           }).slice();
+          const snapshotPayload = encodeBase64Unicode(
+            JSON.stringify(captureTriOrbStateSnapshot())
+          );
           lines.push("");
           if (!triorbSource) {
             triorbSource = "TriOrbAware";
@@ -6524,6 +6893,9 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
           const shapeLines = buildTriOrbShapesXml();
           shapeLines.forEach((line) => lines.push(line));
           lines.push("  </TriOrbMenu>");
+          lines.push(
+            `  <StateSnapshot Format="json" Encoding="base64" Version="${triOrbStateSnapshotVersion}">${snapshotPayload}</StateSnapshot>`
+          );
           lines.push("</TriOrb_SICK_SLS_Editor>");
           return lines.join("\n");
         }
@@ -6639,6 +7011,29 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
           return merged;
         }
 
+        function resolveFieldShapeReferences(field) {
+          return Array.isArray(field?.shapeRefs)
+            ? field.shapeRefs
+                .map((shapeRef) =>
+                  findTriOrbShapeById(shapeRef.shapeId) ||
+                  triorbShapes.find((shape) => shape.id === shapeRef.shapeId)
+                )
+                .filter(Boolean)
+            : [];
+        }
+
+        function fieldHasInlineGeometry(field) {
+          return (
+            (Array.isArray(field?.polygons) && field.polygons.length > 0) ||
+            (Array.isArray(field?.circles) && field.circles.length > 0) ||
+            (Array.isArray(field?.rectangles) && field.rectangles.length > 0)
+          );
+        }
+
+        function fieldHasSerializableContent(field) {
+          return fieldHasInlineGeometry(field) || resolveFieldShapeReferences(field).length > 0;
+        }
+
         function buildFieldsetsXml(fieldsetDeviceAttrs = null, { includeUserFieldIds = true } = {}) {
           const lines = [];
           lines.push('    <ScanPlane Index="0">');
@@ -6718,26 +7113,22 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
 
           if (fieldsets.length) {
             fieldsets.forEach((fieldset) => {
+              const mergedFields = mergeFieldsByAttributes(fieldset.fields || []);
+              const serializableFields = mergedFields.filter((field) =>
+                fieldHasSerializableContent(field)
+              );
+              if (!serializableFields.length) {
+                return;
+              }
               const attrText = buildAttributeString(
                 stripLatin9Key(fieldset.attributes),
                 getAttributeOrder("Fieldset")
               );
               lines.push(`        <Fieldset${attrText ? " " + attrText : ""}>`);
-              const mergedFields = mergeFieldsByAttributes(fieldset.fields || []);
-              if (mergedFields.length) {
-                mergedFields.forEach((field) => {
-                  const hasInlineGeometry =
-                    (Array.isArray(field.polygons) && field.polygons.length > 0) ||
-                    (Array.isArray(field.circles) && field.circles.length > 0) ||
-                    (Array.isArray(field.rectangles) && field.rectangles.length > 0);
-                  const shapeRefs = Array.isArray(field.shapeRefs)
-                    ? field.shapeRefs
-                        .map((shapeRef) =>
-                          findTriOrbShapeById(shapeRef.shapeId) ||
-                          triorbShapes.find((shape) => shape.id === shapeRef.shapeId)
-                        )
-                        .filter(Boolean)
-                    : [];
+              if (serializableFields.length) {
+                serializableFields.forEach((field) => {
+                  const hasInlineGeometry = fieldHasInlineGeometry(field);
+                  const shapeRefs = resolveFieldShapeReferences(field);
 
                   if (
                     Array.isArray(field.shapeRefs) &&
@@ -6834,8 +7225,6 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
                   }
                   lines.push("          </Field>");
                 });
-              } else {
-                lines.push("          <!-- No fields -->");
               }
               lines.push("        </Fieldset>");
             });
@@ -7410,21 +7799,22 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
             const numericIndex = Number.parseInt(indexValue, 10);
             const planeId = attrs.Id || (Number.isFinite(numericIndex) ? String(numericIndex + 1) : String(planeIndex + 1));
             const nameValue = attrs.Name || `ScanPlane ${planeIndex + 1}`;
-            const userFieldsetsNode = fieldsetsAssigned
-              ? { tag: "UserFieldsets", attributes: {}, text: "", children: [] }
-              : buildFieldsConfigurationUserFieldsets(counter);
+            const children = [
+              { tag: "Index", attributes: {}, text: String(indexValue), children: [] },
+              { tag: "Name", attributes: {}, text: nameValue, children: [] },
+            ];
             if (!fieldsetsAssigned) {
+              const userFieldsetsNode = buildFieldsConfigurationUserFieldsets(counter);
+              if (userFieldsetsNode) {
+                children.push(userFieldsetsNode);
+              }
               fieldsetsAssigned = true;
             }
             return {
               tag: "ScanPlane",
               attributes: { Id: String(planeId) },
               text: "",
-              children: [
-                { tag: "Index", attributes: {}, text: String(indexValue), children: [] },
-                { tag: "Name", attributes: {}, text: nameValue, children: [] },
-                userFieldsetsNode,
-              ],
+              children,
             };
           });
         }
@@ -7432,6 +7822,10 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
         function buildFieldsConfigurationUserFieldsets(counter) {
           const fieldsetNodes = Array.isArray(fieldsets)
             ? fieldsets.map((fieldset, fieldsetIndex) => {
+                const userFields = buildFieldsConfigurationUserFields(fieldset, fieldsetIndex, counter);
+                if (!userFields.length) {
+                  return null;
+                }
                 const attrs = fieldset?.attributes || {};
                 return {
                   tag: "UserFieldset",
@@ -7444,17 +7838,22 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
                       tag: "UserFields",
                       attributes: {},
                       text: "",
-                      children: buildFieldsConfigurationUserFields(fieldset, fieldsetIndex, counter),
+                      children: userFields,
                     },
                   ],
                 };
-              })
+              }).filter(Boolean)
             : [];
+          if (!fieldsetNodes.length) {
+            return null;
+          }
           return { tag: "UserFieldsets", attributes: {}, text: "", children: fieldsetNodes };
         }
 
         function buildFieldsConfigurationUserFields(fieldset, fieldsetIndex, counter) {
-          const fields = Array.isArray(fieldset?.fields) ? mergeFieldsByAttributes(fieldset.fields) : [];
+          const fields = Array.isArray(fieldset?.fields)
+            ? mergeFieldsByAttributes(fieldset.fields).filter((field) => fieldHasSerializableContent(field))
+            : [];
           return fields.map((field, fieldIndex) => {
             const attrs = field?.attributes || {};
             const primaryShapeId = findPrimaryShapeIdForField(field);
@@ -8509,6 +8908,29 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
             findFirstByTag(doc, "TriOrb_SICK_SLS_Editor");
           triOrbImportContext = { triOrbRootFound: Boolean(triOrbRoot) };
           console.log("parseXmlToFigure TriOrb root exists", Boolean(triOrbRoot));
+          if (triOrbRoot) {
+            try {
+              const snapshot = readTriOrbStateSnapshot(triOrbRoot);
+              if (snapshot) {
+                restoreTriOrbStateSnapshot(snapshot);
+                const restoredFigure = cloneFigure(currentFigure || defaultFigure);
+                return {
+                  traces: restoredFigure.data || [],
+                  layout: restoredFigure.layout || cloneFigure(defaultFigure).layout,
+                  warning: warningMessage,
+                  triOrbPresent: true,
+                };
+              }
+            } catch (error) {
+              warningMessage = [
+                warningMessage,
+                "TriOrb snapshot could not be restored; falling back to XML parsing.",
+              ]
+                .filter(Boolean)
+                .join(" ");
+              console.warn("TriOrb snapshot restore failed", error);
+            }
+          }
           if (!triOrbRoot) {
             const nodesWithTriOrbInName = [];
             const nodesWithTriOrbAttrs = [];
@@ -8703,13 +9125,23 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
           const tracesFromPlotData = parsePlotDataTraces(doc);
           if (tracesFromPlotData.length) {
             const triOrbPresent = Boolean(triOrbDoc.querySelector("TriOrb_SICK_SLS_Editor"));
-            return { traces: tracesFromPlotData, warning: warningMessage, triOrbPresent };
+            return {
+              traces: tracesFromPlotData,
+              layout: cloneFigure(defaultFigure).layout,
+              warning: warningMessage,
+              triOrbPresent,
+            };
           }
 
           const polygonTrace = parsePolygonTrace(doc);
           if (polygonTrace.length) {
             const triOrbPresent = Boolean(triOrbDoc.querySelector("TriOrb_SICK_SLS_Editor"));
-            return { traces: polygonTrace, warning: warningMessage, triOrbPresent };
+            return {
+              traces: polygonTrace,
+              layout: cloneFigure(defaultFigure).layout,
+              warning: warningMessage,
+              triOrbPresent,
+            };
           }
 
           const combinedWarning = [
@@ -8720,6 +9152,7 @@ function buildCircleTrace(circle, colorSet, label, fieldType, fieldsetIndex, fie
             .join(" ");
           return {
             traces: [],
+            layout: cloneFigure(defaultFigure).layout,
             warning: combinedWarning,
             triOrbPresent: Boolean(triOrbDoc.querySelector("TriOrb_SICK_SLS_Editor")),
           };
@@ -8852,7 +9285,11 @@ function parsePolygonTrace(doc) {
 
         function collectTriOrbShapeDetails(shapeNode) {
           const type = shapeNode.getAttribute("Type") || "Polygon";
-          const result = { id: shapeNode.getAttribute("ID") || createShapeId(), name: shapeNode.getAttribute("Name") || "", type };
+          const result = {
+            id: shapeNode.getAttribute("ID") || createShapeId(),
+            name: sanitizeLoadedShapeName(shapeNode.getAttribute("Name") || "", type),
+            type,
+          };
           if (type === "Polygon") {
             const polygon = findFirstByTag(shapeNode, "Polygon");
             if (polygon) {
@@ -11776,6 +12213,8 @@ function parsePolygonTrace(doc) {
         let createShapeModalOffsetY = 0;
         let createShapeDragStartX = 0;
         let createShapeDragStartY = 0;
+        let createShapeResizeStartX = 0;
+        let createShapeResizeStartY = 0;
         let isCreateShapeDragging = false;
         let isCreateShapeResizing = false;
         let createShapeInitialWidth = 0;
@@ -12045,6 +12484,10 @@ function parsePolygonTrace(doc) {
             button.classList.toggle("active", isActive);
             button.setAttribute("aria-pressed", String(isActive));
           });
+          const orderedIndexes = Array.from(indexSet).filter(Number.isFinite).sort((a, b) => a - b);
+          createShapeFieldsetSelectionAnchor = orderedIndexes.length
+            ? orderedIndexes[orderedIndexes.length - 1]
+            : null;
         }
 
         function getFieldsetIndexesReferencingShape(shapeId) {
@@ -12129,6 +12572,7 @@ function parsePolygonTrace(doc) {
           renderCreateShapeFieldsetsList();
 
           setCreateShapeFieldsetSelections([]);
+          createShapeFieldsetSelectionAnchor = null;
 
           createShapeDraftId = createShapeId();
 
@@ -12181,6 +12625,9 @@ function parsePolygonTrace(doc) {
           populateCreateShapeForm(shape);
           const referencing = getFieldsetIndexesReferencingShape(shape.id);
           setCreateShapeFieldsetSelections(referencing);
+          createShapeFieldsetSelectionAnchor = referencing.length
+            ? referencing[referencing.length - 1]
+            : null;
           createShapeDraftId = shape.id;
           if (createShapeModalTitle) {
             createShapeModalTitle.textContent = "Edit Shape";
@@ -12209,6 +12656,7 @@ function parsePolygonTrace(doc) {
           createShapeMode = "create";
           createShapeEditingId = null;
           createShapeOriginal = null;
+          createShapeFieldsetSelectionAnchor = null;
           if (createShapeModalTitle) {
             createShapeModalTitle.textContent = "Add Shape";
           }
@@ -12312,8 +12760,33 @@ function parsePolygonTrace(doc) {
               return;
             }
             event.preventDefault();
-            const isActive = button.classList.toggle("active");
-            button.setAttribute("aria-pressed", isActive ? "true" : "false");
+            const index = Number(button.dataset.createFieldsetIndex);
+            if (!Number.isFinite(index)) {
+              return;
+            }
+            const selectedIndexes = new Set(getCreateShapeSelectedFieldsets());
+            const nextState = !button.classList.contains("active");
+            if (event.shiftKey && createShapeFieldsetSelectionAnchor !== null) {
+              const start = Math.min(createShapeFieldsetSelectionAnchor, index);
+              const end = Math.max(createShapeFieldsetSelectionAnchor, index);
+              for (let current = start; current <= end; current += 1) {
+                if (nextState) {
+                  selectedIndexes.add(current);
+                } else {
+                  selectedIndexes.delete(current);
+                }
+              }
+              setCreateShapeFieldsetSelections(Array.from(selectedIndexes));
+              createShapeFieldsetSelectionAnchor = index;
+              return;
+            }
+            if (nextState) {
+              selectedIndexes.add(index);
+            } else {
+              selectedIndexes.delete(index);
+            }
+            setCreateShapeFieldsetSelections(Array.from(selectedIndexes));
+            createShapeFieldsetSelectionAnchor = index;
           });
         }
         if (createFieldModal) {
@@ -12813,8 +13286,7 @@ function parsePolygonTrace(doc) {
           const reader = new FileReader();
           reader.onload = () => {
             try {
-              const { traces, warning, triOrbPresent } = parseXmlToFigure(reader.result);
-              const layout = cloneFigure(defaultFigure).layout;
+              const { traces, layout, warning, triOrbPresent } = parseXmlToFigure(reader.result);
               currentFigure = { data: traces, layout };
               invalidateBaseFigureTraces();
               renderFigure();
@@ -12936,12 +13408,52 @@ function parsePolygonTrace(doc) {
         }
         document.addEventListener("pointermove", updateModalDrag);
         document.addEventListener("pointerup", endModalDrag);
+        floatingPanelLauncherButtons.forEach((button) => {
+          button.addEventListener("click", () => {
+            toggleFloatingPanel(button.dataset.panelTarget);
+          });
+        });
+        floatingPanels.forEach((panel) => {
+          panel.addEventListener("pointerdown", (event) => {
+            if (event.target.closest("[data-panel-close]")) {
+              closeFloatingPanel(panel);
+              return;
+            }
+            bringFloatingPanelToFront(panel);
+          });
+          panel
+            .querySelector("[data-panel-drag-handle]")
+            ?.addEventListener("pointerdown", handleFloatingPanelPointerDown);
+        });
+        document.addEventListener("pointermove", handleFloatingPanelPointerMove);
+        document.addEventListener("pointerup", handleFloatingPanelPointerUp);
+        window.addEventListener("resize", () => {
+          floatingPanels.forEach((panel) => {
+            if (panel.classList.contains("active")) {
+              constrainFloatingPanelToViewport(panel);
+            }
+          });
+        });
+        syncFloatingPanelLauncherStates();
 
         setupLayoutObservers();
         renderFigure();
 
         window.__triorbTestApi = {
           buildTriOrbXml: () => buildTriOrbXml(),
+          buildLegacyXml: () => buildLegacyXml(),
+          getStateSnapshot: () => captureTriOrbStateSnapshot(),
+          loadXml: (xmlText) => {
+            const parsed = parseXmlToFigure(xmlText);
+            currentFigure = { data: parsed.traces, layout: parsed.layout };
+            invalidateBaseFigureTraces();
+            renderFigure();
+            return parsed;
+          },
+          restoreStateSnapshot: (snapshot) => {
+            restoreTriOrbStateSnapshot(snapshot);
+            renderFigure();
+          },
         };
 
         function setupLayoutObservers() {

--- a/static/js/modules/triorbData.js
+++ b/static/js/modules/triorbData.js
@@ -2,6 +2,39 @@ export function createShapeId() {
   return `shape-${Math.random().toString(36).slice(2, 10)}`;
 }
 
+export function sanitizeLoadedShapeName(value, shapeType = "") {
+  const raw = String(value ?? "").trim();
+  if (!raw) {
+    return raw;
+  }
+  const normalizedShapeType = String(shapeType || "").trim().toLowerCase();
+  const suffixCandidates = [];
+  if (normalizedShapeType === "polygon") {
+    suffixCandidates.push(" Protective Polygon", " Warning Polygon");
+  } else if (normalizedShapeType === "rectangle") {
+    suffixCandidates.push(" Protective Rectangle", " Warning Rectangle");
+  } else if (normalizedShapeType === "circle") {
+    suffixCandidates.push(" Protective Circle", " Warning Circle");
+  } else {
+    suffixCandidates.push(
+      " Protective Polygon",
+      " Warning Polygon",
+      " Protective Rectangle",
+      " Warning Rectangle",
+      " Protective Circle",
+      " Warning Circle"
+    );
+  }
+
+  for (const suffix of suffixCandidates) {
+    if (raw.endsWith(suffix)) {
+      const trimmed = raw.slice(0, -suffix.length).trim();
+      return trimmed || raw;
+    }
+  }
+  return raw;
+}
+
 export function createDefaultPolygonDetails() {
   return {
     Type: "CutOut",
@@ -154,7 +187,7 @@ export function initializeTriOrbShapes(data) {
     circle.Type = circle.Type || inferredKind;
     const normalizedShape = {
       id: shape.id || createShapeId(),
-      name: shape.name || `Shape ${index + 1}`,
+      name: sanitizeLoadedShapeName(shape.name || `Shape ${index + 1}`, shape.type || "Polygon"),
       type: shape.type || "Polygon",
       fieldtype,
       kind: inferredKind,

--- a/templates/index.html
+++ b/templates/index.html
@@ -58,22 +58,18 @@
     }
 
     .side-menu {
-      flex: 0 0 360px;
-      max-height: calc(100vh - 4rem);
-      overflow-y: auto;
-      padding-right: 0.5rem;
+      flex: 0 0 220px;
+      min-width: 220px;
+      background: linear-gradient(180deg, #f8fbfe 0%, #eef4f8 100%);
+      border-radius: 14px;
+      padding: 1rem;
+      box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.06);
       position: sticky;
       top: 2rem;
       align-self: flex-start;
-    }
-
-    .side-menu::-webkit-scrollbar {
-      width: 6px;
-    }
-
-    .side-menu::-webkit-scrollbar-thumb {
-      background: rgba(15, 23, 42, 0.25);
-      border-radius: 3px;
+      display: flex;
+      flex-direction: column;
+      gap: 0.85rem;
     }
 
     .toolbar {
@@ -213,21 +209,104 @@
       font-size: 0.9rem;
     }
 
-    .side-menu {
-      flex: 0 0 auto;
-      min-width: 220px;
-      max-width: 40%;
-      width: fit-content;
-      background: #f6f8fb;
-      border-radius: 10px;
-      padding: 1rem;
-      box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.05);
-    }
-
     .side-menu h2 {
       font-size: 1rem;
       margin: 0 0 0.75rem;
       color: #1f2937;
+    }
+
+    .side-menu-note {
+      margin: 0;
+      color: #475569;
+      font-size: 0.85rem;
+      line-height: 1.5;
+    }
+
+    .floating-panel-launchers {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.6rem;
+    }
+
+    .panel-launch-btn {
+      justify-content: center;
+      min-height: 3rem;
+      background: #0f172a;
+      color: #f8fafc;
+      border-radius: 10px;
+      padding: 0.75rem 0.5rem;
+      font-size: 0.82rem;
+      text-align: center;
+      line-height: 1.35;
+    }
+
+    .panel-launch-btn.active {
+      background: #0b6fb8;
+    }
+
+    .floating-panel {
+      position: fixed;
+      top: 7rem;
+      right: 1.5rem;
+      width: min(560px, calc(100vw - 3rem));
+      max-height: calc(100vh - 9rem);
+      display: none;
+      flex-direction: column;
+      background: #ffffff;
+      border: 1px solid rgba(15, 23, 42, 0.12);
+      border-radius: 14px;
+      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.22);
+      overflow: hidden;
+      z-index: 40;
+    }
+
+    .floating-panel.active {
+      display: flex;
+    }
+
+    .floating-panel[data-panel-size="wide"] {
+      width: min(720px, calc(100vw - 3rem));
+    }
+
+    .floating-panel-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      padding: 0.85rem 1rem;
+      background: linear-gradient(135deg, #0b6fb8 0%, #155e75 100%);
+      color: #ffffff;
+      cursor: move;
+      user-select: none;
+    }
+
+    .floating-panel-title {
+      font-size: 0.95rem;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+    }
+
+    .floating-panel-body {
+      overflow: auto;
+      padding: 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.85rem;
+      background: #f8fafc;
+    }
+
+    .floating-panel-body .menu-section,
+    .floating-panel-body .casetable-section {
+      margin-bottom: 0;
+    }
+
+    .floating-panel-body::-webkit-scrollbar {
+      width: 8px;
+    }
+
+    .floating-panel-body::-webkit-scrollbar-thumb {
+      background: rgba(15, 23, 42, 0.18);
+      border-radius: 999px;
     }
 
     .menu-section {
@@ -1641,6 +1720,15 @@
 
       .side-menu {
         width: 100%;
+        min-width: 0;
+        position: static;
+      }
+
+      .floating-panel {
+        left: 1rem;
+        right: 1rem;
+        width: auto;
+        max-height: 70vh;
       }
     }
   </style>
@@ -1789,7 +1877,7 @@
           </div>
         </div>
         <div class="modal-section preview-note">
-          <p>Selected shapes render on the Plotly canvas in red preview while editing.</p>
+          <p>Selected shapes render on the Plotly canvas in red preview while editing. Shift + click selects a range.</p>
         </div>
       </div>
       <div class="modal-footer">
@@ -2059,15 +2147,25 @@
         <div id="triorb-shape-checkboxes"></div>
       </div>
     </section>
-    <!-- サイドメニュー: XML構造を表示する領域 -->
+    <!-- 右側ドック: 6ボタンで各編集ツリーをフローティング表示 -->
     <aside class="side-menu">
-      <h2>Structure Menu</h2>
-      {% for item in menu_items %}
-      <details class="menu-section" {% if loop.first and item.tag !="FileInfo" %}open{% endif %}>
-        <summary>{{ item.tag }}</summary>
-        <div class="menu-content">
-          {% if item.tag == "FileInfo" %}
-          <p class="menu-description">{{ item.summary }}</p>
+      <h2>Editors</h2>
+      <p class="side-menu-note">右側の編集ツリーは必要なときだけフローティング表示します。</p>
+      <div class="floating-panel-launchers">
+        <button type="button" class="panel-launch-btn" data-panel-target="panel-fileinfo">FileInfo</button>
+        <button type="button" class="panel-launch-btn" data-panel-target="panel-scanplanes">ScanPlanes</button>
+        <button type="button" class="panel-launch-btn" data-panel-target="panel-fieldsets">Fieldsets</button>
+        <button type="button" class="panel-launch-btn" data-panel-target="panel-casetable">Casetable</button>
+        <button type="button" class="panel-launch-btn" data-panel-target="panel-triorb-settings">TriOrb Settings</button>
+        <button type="button" class="panel-launch-btn" data-panel-target="panel-triorb-shapes">TriOrb Shapes</button>
+      </div>
+
+      <section class="floating-panel" id="panel-fileinfo">
+        <div class="floating-panel-header" data-panel-drag-handle>
+          <span class="floating-panel-title">FileInfo</span>
+          <button type="button" class="inline-btn secondary shape-mini-btn" data-panel-close>×</button>
+        </div>
+        <div class="floating-panel-body">
           {% if fileinfo_fields %}
           <div class="menu-fileinfo-grid" data-scope="fileinfo">
             {% for field in fileinfo_fields %}
@@ -2080,12 +2178,26 @@
           {% else %}
           <p>No FileInfo entries.</p>
           {% endif %}
-          {% elif item.tag == "Export_ScanPlanes" %}
-          <p class="menu-description">{{ item.summary }}</p>
+        </div>
+      </section>
+
+      <section class="floating-panel" id="panel-scanplanes">
+        <div class="floating-panel-header" data-panel-drag-handle>
+          <span class="floating-panel-title">ScanPlanes</span>
+          <button type="button" class="inline-btn secondary shape-mini-btn" data-panel-close>×</button>
+        </div>
+        <div class="floating-panel-body">
           <button type="button" class="inline-btn" id="btn-add-scanplane">Add ScanPlane</button>
           <div class="scanplanes-editor" id="scanplanes-editor"></div>
-          {% elif item.tag == "Export_FieldsetsAndFields" %}
-          <p class="menu-description">{{ item.summary }}</p>
+        </div>
+      </section>
+
+      <section class="floating-panel" id="panel-fieldsets">
+        <div class="floating-panel-header" data-panel-drag-handle>
+          <span class="floating-panel-title">Fieldsets</span>
+          <button type="button" class="inline-btn secondary shape-mini-btn" data-panel-close>×</button>
+        </div>
+        <div class="floating-panel-body">
           <button type="button" class="inline-btn" id="btn-add-fieldset">Add Fieldset</button>
           <details class="menu-section" id="fieldset-global-section">
             <summary>GlobalGeometry</summary>
@@ -2105,7 +2217,15 @@
             </div>
           </details>
           <div class="fieldsets-editor" id="fieldsets-editor"></div>
-          {% elif item.tag == "Export_CasetablesAndCases" %}
+        </div>
+      </section>
+
+      <section class="floating-panel" id="panel-casetable" data-panel-size="wide">
+        <div class="floating-panel-header" data-panel-drag-handle>
+          <span class="floating-panel-title">Casetable</span>
+          <button type="button" class="inline-btn secondary shape-mini-btn" data-panel-close>×</button>
+        </div>
+        <div class="floating-panel-body">
           <div class="casetable-section">
             <h3>Configuration</h3>
             <div class="casetable-configuration" id="casetable-configuration"></div>
@@ -2139,27 +2259,68 @@
             </p>
             <div class="casetable-fields-configuration" id="casetable-fields-configuration"></div>
           </div>
-          {% else %}
-          <p>{{ item.summary }}</p>
-          {% endif %}
         </div>
-      </details>
-      {% endfor %}
-      <h2>TriOrb Menu</h2>
-      <details class="menu-section">
-        <summary>Device</summary>
-        <div class="menu-content">
-          <div class="menu-fileinfo-grid">
-            <div class="triorb-field">
-              <label>FieldOfView</label>
-              <input type="number" id="triorb-field-of-view" value="270" min="1" max="360" step="1" />
+      </section>
+
+      <section class="floating-panel" id="panel-triorb-settings">
+        <div class="floating-panel-header" data-panel-drag-handle>
+          <span class="floating-panel-title">TriOrb Settings</span>
+          <button type="button" class="inline-btn secondary shape-mini-btn" data-panel-close>×</button>
+        </div>
+        <div class="floating-panel-body">
+          <details class="menu-section" open>
+            <summary>Device</summary>
+            <div class="menu-content">
+              <div class="menu-fileinfo-grid">
+                <div class="triorb-field">
+                  <label>FieldOfView</label>
+                  <input type="number" id="triorb-field-of-view" value="270" min="1" max="360" step="1" />
+                </div>
+              </div>
             </div>
-          </div>
+          </details>
+          <details class="menu-section" open>
+            <summary>Common</summary>
+            <div class="menu-content">
+              <div class="menu-fileinfo-grid">
+                <div class="triorb-field">
+                  <label>MultipleSampling (2-16)</label>
+                  <input id="global-multiple-sampling" type="number" min="2" max="16" value="2" />
+                </div>
+                <div class="triorb-field">
+                  <label>Resolution</label>
+                  <input id="global-resolution" type="number" min="1" max="1000" value="70" />
+                </div>
+                <div class="triorb-field">
+                  <label>TolerancePositive</label>
+                  <input id="global-tolerance-positive" type="number" value="0" />
+                </div>
+                <div class="triorb-field">
+                  <label>ToleranceNegative</label>
+                  <input id="global-tolerance-negative" type="number" value="0" />
+                </div>
+              </div>
+              <details class="menu-section">
+                <summary>CommonCutOut #1</summary>
+                <div class="menu-content">
+                  <ul>
+                    <li>Polygon #1</li>
+                    <li>Circle #1</li>
+                    <li>Rectangle #1</li>
+                  </ul>
+                </div>
+              </details>
+            </div>
+          </details>
         </div>
-      </details>
-      <details class="menu-section">
-        <summary>Shapes</summary>
-        <div class="menu-content">
+      </section>
+
+      <section class="floating-panel" id="panel-triorb-shapes">
+        <div class="floating-panel-header" data-panel-drag-handle>
+          <span class="floating-panel-title">TriOrb Shapes</span>
+          <button type="button" class="inline-btn secondary shape-mini-btn" data-panel-close>×</button>
+        </div>
+        <div class="floating-panel-body">
           <div class="fieldset-actions">
             <button type="button" class="inline-btn" id="btn-add-triorb-shape">
               Add Shape
@@ -2167,40 +2328,7 @@
           </div>
           <div class="triorb-shapes-list" id="triorb-shapes-list"></div>
         </div>
-      </details>
-      <details class="menu-section">
-        <summary>Common</summary>
-        <div class="menu-content">
-          <div class="menu-fileinfo-grid">
-            <div class="triorb-field">
-              <label>MultipleSampling (2-16)</label>
-              <input id="global-multiple-sampling" type="number" min="2" max="16" value="2" />
-            </div>
-            <div class="triorb-field">
-              <label>Resolution</label>
-              <input id="global-resolution" type="number" min="1" max="1000" value="70" />
-            </div>
-            <div class="triorb-field">
-              <label>TolerancePositive</label>
-              <input id="global-tolerance-positive" type="number" value="0" />
-            </div>
-            <div class="triorb-field">
-              <label>ToleranceNegative</label>
-              <input id="global-tolerance-negative" type="number" value="0" />
-            </div>
-          </div>
-          <details class="menu-section">
-            <summary>CommonCutOut #1</summary>
-            <div class="menu-content">
-              <ul>
-                <li>Polygon #1</li>
-                <li>Circle #1</li>
-                <li>Rectangle #1</li>
-              </ul>
-            </div>
-          </details>
-        </div>
-      </details>
+      </section>
     </aside>
   </main>
   <footer>Flask + Plotly powered preview</footer>

--- a/tests/playwright/test_shapes.py
+++ b/tests/playwright/test_shapes.py
@@ -1,45 +1,56 @@
 from playwright.sync_api import sync_playwright
 import sys
+import os
+from pathlib import Path
 
-from tests.conftest import launch_chromium
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tests.conftest import SERVER_URL, launch_chromium
 
 
 def run_playwright_test():
     # Flask サーバーを別プロセスで起動している前提で、
     # TriOrb のグローバル入力が Fieldset に伝播するかを最小限確認する。
-    server_url = "http://127.0.0.1:5000/?debug=1"
+    server_url = os.environ.get("PLAYWRIGHT_SERVER_URL", SERVER_URL)
     with sync_playwright() as p:
         browser = launch_chromium(p)
         page = browser.new_page()
         errors = []
         page.on("console", lambda msg: errors.append(msg) if msg.type == "error" else None)
         page.goto(server_url, wait_until="networkidle")
+        page.evaluate("document.querySelector('[data-panel-target=\"panel-triorb-settings\"]').click()")
+        page.evaluate("document.querySelector('[data-panel-target=\"panel-fieldsets\"]').click()")
+        page.locator(".fieldset-details").first.evaluate("node => (node.open = true)")
+        page.locator(".field-details").first.evaluate("node => (node.open = true)")
         page.fill("#global-multiple-sampling", "5")
         page.fill("#global-resolution", "80")
         page.fill("#global-tolerance-positive", "3")
         page.fill("#global-tolerance-negative", "2")
         page.wait_for_timeout(500)
         first_field_multiple = page.locator(
-            'input.field-attr[data-field="MultipleSampling"]'
+            '.field-attribute:has(label:text("MultipleSampling")) input'
         ).first
         if first_field_multiple.input_value() != "5":
             raise AssertionError("MultipleSampling did not update on Fieldset input.")
         resolution_field = page.locator(
-            'input.field-attr[data-field="Resolution"]'
+            '.field-attribute:has(label:text("Resolution")) input'
         ).first
         if resolution_field.input_value() != "80":
             raise AssertionError("Resolution did not sync to Fieldset.")
         positive_field = page.locator(
-            'input.field-attr[data-field="TolerancePositive"]'
+            '.field-attribute:has(label:text("TolerancePositive")) input'
         ).first
         negative_field = page.locator(
-            'input.field-attr[data-field="ToleranceNegative"]'
+            '.field-attribute:has(label:text("ToleranceNegative")) input'
         ).first
         if positive_field.input_value() != "3" or negative_field.input_value() != "2":
             raise AssertionError("Tolerance values did not propagate.")
         buttons = [
             "#btn-new",
-            "#btn-save",
+            "#btn-save-triorb",
+            "#btn-save-sick",
             "#btn-toggle-legend",
             "#btn-fieldset-check-all",
             "#btn-fieldset-uncheck-all",

--- a/tests/playwright/test_triorb_snapshot_roundtrip.py
+++ b/tests/playwright/test_triorb_snapshot_roundtrip.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import sync_playwright
+
+from tests.conftest import SERVER_URL, launch_chromium
+
+
+def _normalize_snapshot(snapshot: dict) -> dict:
+    normalized = copy.deepcopy(snapshot)
+    return normalized
+
+
+def test_bootstrap_keeps_default_fieldset_devices(flask_server):
+    with sync_playwright() as playwright:
+        browser = launch_chromium(playwright)
+        try:
+            page = browser.new_page()
+            page.goto(SERVER_URL, wait_until="networkidle")
+            page.wait_for_function("window.__triorbTestApi !== undefined")
+
+            snapshot = page.evaluate("window.__triorbTestApi.getStateSnapshot()")
+            coords = {
+                (
+                    device["attributes"].get("PositionX"),
+                    device["attributes"].get("PositionY"),
+                    device["attributes"].get("Rotation"),
+                )
+                for device in snapshot["fieldsetDevices"]
+            }
+            assert ("170", "102", "290") in coords
+            assert ("-170", "102", "70") in coords
+        finally:
+            browser.close()
+
+
+def test_triorb_snapshot_roundtrip_restores_exact_state(flask_server):
+    with sync_playwright() as playwright:
+        browser = launch_chromium(playwright)
+        try:
+            page = browser.new_page()
+            page.goto(SERVER_URL, wait_until="networkidle")
+            page.wait_for_function("window.__triorbTestApi !== undefined")
+
+            snapshot = page.evaluate("window.__triorbTestApi.getStateSnapshot()")
+            assert snapshot["triorbShapes"], "Expected at least one TriOrb shape in bootstrap data"
+            assert snapshot["fieldsets"], "Expected at least one fieldset in bootstrap data"
+            assert snapshot["scanPlanes"], "Expected at least one scanplane in bootstrap data"
+
+            base_shape = copy.deepcopy(snapshot["triorbShapes"][0])
+            duplicate_shape = copy.deepcopy(base_shape)
+            duplicate_shape["id"] = "shape-duplicate"
+            duplicate_shape["name"] = "Exact Duplicate"
+            snapshot["triorbShapes"].append(duplicate_shape)
+
+            first_field = snapshot["fieldsets"][0]["fields"][0]
+            first_field.setdefault("shapeRefs", [])
+            first_field["shapeRefs"].append({"shapeId": "shape-duplicate"})
+
+            scan_device = copy.deepcopy(snapshot["scanPlanes"][0]["devices"][0])
+            scan_device["attributes"]["Index"] = "1"
+            scan_device["attributes"]["DeviceName"] = "Left"
+            snapshot["scanPlanes"][0]["devices"] = [
+                {
+                    "attributes": {
+                        **scan_device["attributes"],
+                        "Index": "0",
+                        "DeviceName": "Right",
+                    }
+                },
+                scan_device,
+            ]
+
+            fieldset_device = copy.deepcopy(snapshot["fieldsetDevices"][0])
+            fieldset_device["attributes"]["DeviceName"] = "Left"
+            snapshot["fieldsetDevices"] = [
+                {
+                    "attributes": {
+                        **fieldset_device["attributes"],
+                        "DeviceName": "Right",
+                    }
+                },
+                fieldset_device,
+            ]
+
+            page.evaluate(
+                "snapshot => window.__triorbTestApi.restoreStateSnapshot(snapshot)",
+                snapshot,
+            )
+            before = _normalize_snapshot(
+                page.evaluate("window.__triorbTestApi.getStateSnapshot()")
+            )
+
+            xml_text = page.evaluate("window.__triorbTestApi.buildTriOrbXml()")
+            assert "<StateSnapshot" in xml_text
+
+            page.evaluate("xml => window.__triorbTestApi.loadXml(xml)", xml_text)
+            after = _normalize_snapshot(
+                page.evaluate("window.__triorbTestApi.getStateSnapshot()")
+            )
+
+            assert before == after
+        finally:
+            browser.close()
+
+
+def test_shape_assignment_modal_supports_shift_range_selection(flask_server):
+    with sync_playwright() as playwright:
+        browser = launch_chromium(playwright)
+        try:
+            page = browser.new_page()
+            page.goto(SERVER_URL, wait_until="networkidle")
+            page.wait_for_function("window.__triorbTestApi !== undefined")
+
+            snapshot = page.evaluate("window.__triorbTestApi.getStateSnapshot()")
+            snapshot["triorbShapes"] = []
+            for index in range(4):
+                snapshot["triorbShapes"].append(
+                    {
+                        "id": f"field-shape-{index + 1}",
+                        "name": f"Field Shape {index + 1}",
+                        "type": "Polygon",
+                        "fieldtype": "ProtectiveSafeBlanking",
+                        "kind": "Field",
+                        "polygon": {
+                            "Type": "Field",
+                            "points": [
+                                {"X": str(index * 10), "Y": "0"},
+                                {"X": str(index * 10 + 20), "Y": "0"},
+                                {"X": str(index * 10 + 20), "Y": "20"},
+                            ],
+                        },
+                        "rectangle": {
+                            "Type": "Field",
+                            "OriginX": "0",
+                            "OriginY": "0",
+                            "Width": "10",
+                            "Height": "10",
+                            "Rotation": "0",
+                        },
+                        "circle": {
+                            "Type": "Field",
+                            "CenterX": "0",
+                            "CenterY": "0",
+                            "Radius": "10",
+                        },
+                        "visible": True,
+                    }
+                )
+
+            page.evaluate(
+                "snapshot => window.__triorbTestApi.restoreStateSnapshot(snapshot)",
+                snapshot,
+            )
+
+            page.click("#btn-add-field-overlay")
+            modal = page.locator("#create-field-modal")
+            modal.wait_for(state="visible")
+
+            buttons = page.locator("#create-field-shape-list-0-field .create-field-shape-btn")
+            buttons.nth(0).click()
+            buttons.nth(2).click(modifiers=["Shift"])
+
+            active_count = page.locator(
+                "#create-field-shape-list-0-field .create-field-shape-btn.active"
+            ).count()
+            assert active_count == 3
+        finally:
+            browser.close()
+
+
+def test_create_shape_attach_to_fieldsets_supports_shift_range_selection(flask_server):
+    source_path = Path(__file__).resolve().parents[2] / "TriOrb_1776337392610.sgexml"
+    if not source_path.exists():
+        pytest.skip(f"Source XML not found: {source_path}")
+    xml_text = source_path.read_text(encoding="utf-8")
+
+    with sync_playwright() as playwright:
+        browser = launch_chromium(playwright)
+        try:
+            page = browser.new_page()
+            page.goto(SERVER_URL, wait_until="networkidle")
+            page.wait_for_function("window.__triorbTestApi !== undefined")
+            page.evaluate("xml => window.__triorbTestApi.loadXml(xml)", xml_text)
+
+            page.click("#btn-add-shape-overlay")
+            page.locator("#create-shape-modal").wait_for(state="visible")
+
+            buttons = page.locator("#create-shape-fieldset-list .toggle-pill-btn")
+            buttons.nth(0).click()
+            buttons.nth(3).click(modifiers=["Shift"])
+
+            active_count = page.locator(
+                "#create-shape-fieldset-list .toggle-pill-btn.active"
+            ).count()
+            assert active_count == 4
+        finally:
+            browser.close()
+
+
+def test_create_shape_modal_resize_handle_works_without_reference_error(flask_server):
+    with sync_playwright() as playwright:
+        browser = launch_chromium(playwright)
+        try:
+            page = browser.new_page()
+            errors = []
+            page.on("console", lambda msg: errors.append(msg.text) if msg.type == "error" else None)
+            page.goto(SERVER_URL, wait_until="networkidle")
+            page.wait_for_function("window.__triorbTestApi !== undefined")
+
+            page.click("#btn-add-shape-overlay")
+            page.locator("#create-shape-modal").wait_for(state="visible")
+
+            modal_window = page.locator("#create-shape-modal .modal-window")
+            resize_handle = page.locator("#create-shape-modal .modal-resize-handle").first
+
+            before = modal_window.bounding_box()
+            handle_box = resize_handle.bounding_box()
+            assert before is not None
+            assert handle_box is not None
+
+            page.mouse.move(handle_box["x"] + handle_box["width"] / 2, handle_box["y"] + handle_box["height"] / 2)
+            page.mouse.down()
+            page.mouse.move(handle_box["x"] + 80, handle_box["y"] + 80, steps=8)
+            page.mouse.up()
+
+            after = modal_window.bounding_box()
+            assert after is not None
+            assert after["width"] > before["width"]
+            assert after["height"] > before["height"]
+            assert not any("createShapeResizeStartX is not defined" in error for error in errors)
+        finally:
+            browser.close()
+
+
+def test_sick_save_omits_empty_warning_field_trees(flask_server):
+    with sync_playwright() as playwright:
+        browser = launch_chromium(playwright)
+        try:
+            page = browser.new_page()
+            page.goto(SERVER_URL, wait_until="networkidle")
+            page.wait_for_function("window.__triorbTestApi !== undefined")
+
+            snapshot = page.evaluate("window.__triorbTestApi.getStateSnapshot()")
+            shape_id = snapshot["triorbShapes"][0]["id"]
+            snapshot["fieldsets"] = [
+                {
+                    "attributes": {"Name": "Set A", "Index": "0"},
+                    "fields": [
+                        {
+                            "attributes": {
+                                "Name": "Protective Kept",
+                                "Fieldtype": "ProtectiveSafeBlanking",
+                            },
+                            "shapeRefs": [{"shapeId": shape_id}],
+                            "polygons": [],
+                            "circles": [],
+                            "rectangles": [],
+                        },
+                        {
+                            "attributes": {
+                                "Name": "Warning Empty",
+                                "Fieldtype": "WarningSafeBlanking",
+                            },
+                            "shapeRefs": [],
+                            "polygons": [],
+                            "circles": [],
+                            "rectangles": [],
+                        },
+                    ],
+                    "visible": True,
+                }
+            ]
+
+            page.evaluate(
+                "snapshot => window.__triorbTestApi.restoreStateSnapshot(snapshot)",
+                snapshot,
+            )
+            xml_text = page.evaluate("window.__triorbTestApi.buildLegacyXml()")
+
+            assert "Protective Kept" in xml_text
+            assert "Warning Empty" not in xml_text
+        finally:
+            browser.close()
+
+
+def test_loading_real_file_strips_protective_polygon_suffixes(flask_server):
+    source_path = Path(__file__).resolve().parents[2] / "TriOrb_1776337392610.sgexml"
+    if not source_path.exists():
+        pytest.skip(f"Source XML not found: {source_path}")
+    xml_text = source_path.read_text(encoding="utf-8")
+
+    with sync_playwright() as playwright:
+        browser = launch_chromium(playwright)
+        try:
+            page = browser.new_page()
+            page.goto(SERVER_URL, wait_until="networkidle")
+            page.wait_for_function("window.__triorbTestApi !== undefined")
+
+            page.evaluate("xml => window.__triorbTestApi.loadXml(xml)", xml_text)
+            snapshot = page.evaluate("window.__triorbTestApi.getStateSnapshot()")
+            names = [shape["name"] for shape in snapshot["triorbShapes"]]
+
+            assert "Stop" in names
+            assert "RotCW01" in names
+            assert "Co_RotCW01" in names
+            assert all(not name.endswith("Protective Polygon") for name in names)
+            assert all(not name.endswith("Warning Polygon") for name in names)
+        finally:
+            browser.close()
+
+
+def test_real_file_triorb_roundtrip_does_not_inject_default_fieldset_devices(flask_server):
+    source_path = Path(__file__).resolve().parents[2] / "TriOrb_1776337392610.sgexml"
+    if not source_path.exists():
+        pytest.skip(f"Source XML not found: {source_path}")
+    xml_text = source_path.read_text(encoding="utf-8")
+
+    with sync_playwright() as playwright:
+        browser = launch_chromium(playwright)
+        try:
+            page = browser.new_page()
+            page.goto(SERVER_URL, wait_until="networkidle")
+            page.wait_for_function("window.__triorbTestApi !== undefined")
+
+            page.evaluate("xml => window.__triorbTestApi.loadXml(xml)", xml_text)
+            snapshot = page.evaluate("window.__triorbTestApi.getStateSnapshot()")
+
+            assert len(snapshot["fieldsetDevices"]) == 2
+
+            snapshot["fieldsetDevices"][0]["attributes"]["DeviceName"] = "Left"
+            snapshot["fieldsetDevices"][1]["attributes"]["DeviceName"] = "Right"
+            page.evaluate(
+                "snapshot => window.__triorbTestApi.restoreStateSnapshot(snapshot)",
+                snapshot,
+            )
+
+            roundtrip_xml = page.evaluate("window.__triorbTestApi.buildTriOrbXml()")
+            page.evaluate("xml => window.__triorbTestApi.loadXml(xml)", roundtrip_xml)
+            after = page.evaluate("window.__triorbTestApi.getStateSnapshot()")
+
+            assert len(after["fieldsetDevices"]) == 2
+            coords = {
+                (
+                    device["attributes"].get("PositionX"),
+                    device["attributes"].get("PositionY"),
+                    device["attributes"].get("Rotation"),
+                )
+                for device in after["fieldsetDevices"]
+            }
+            assert ("170", "102", "290") not in coords
+            assert ("-170", "102", "70") not in coords
+        finally:
+            browser.close()


### PR DESCRIPTION
## Summary
- fix TriOrb save/load roundtrip by storing and restoring a full TriOrb snapshot
- keep SICK save focused on export compatibility, including omitting empty warning field trees
- improve editor usability with floating right-side panels, shift-range selection, and fixed modal resize handling
- align Playwright verification with a locally started Flask server and document the workflow in AGENTS.md

## Details
- TriOrb load sanitizes legacy shape names that already contain suffixes such as `Protective Polygon`
- loaded/saved TriOrb files preserve device counts instead of injecting default bootstrap fieldset devices
- `Edit Shape` / `Create Shape` attach lists now support `Shift + click` range selection
- right-side tree auto-scroll behavior is removed in favor of floating panel editing

## Verification
- `powershell -ExecutionPolicy Bypass -File .\\run_playwright.ps1`
- `python -m pytest tests/playwright/test_triorb_snapshot_roundtrip.py tests/playwright/test_device_indices.py -q`

## Notes
- upstream `main` currently has one newer commit than this fork branch, so GitHub will evaluate mergeability against that latest base